### PR TITLE
Syntax parsing for Ada 2022 parallel constructs

### DIFF
--- a/gcc/ada/exp_util.adb
+++ b/gcc/ada/exp_util.adb
@@ -8123,6 +8123,7 @@ package body Exp_Util is
                --  Declarations
 
                | N_Abstract_Subprogram_Declaration
+               | N_Chunk_Specifier
                | N_Entry_Body
                | N_Exception_Declaration
                | N_Exception_Renaming_Declaration

--- a/gcc/ada/exp_util.adb
+++ b/gcc/ada/exp_util.adb
@@ -8148,6 +8148,7 @@ package body Exp_Util is
                | N_Package_Declaration
                | N_Package_Instantiation
                | N_Package_Renaming_Declaration
+               | N_Parallel_Branch
                | N_Private_Extension_Declaration
                | N_Private_Type_Declaration
                | N_Procedure_Instantiation

--- a/gcc/ada/gen_il-fields.ads
+++ b/gcc/ada/gen_il-fields.ads
@@ -92,6 +92,7 @@ package Gen_IL.Fields is
       Check_Address_Alignment,
       Choice_Parameter,
       Choices,
+      Chunk_Specifier,
       Class_Present,
       Classifications,
       Cleanup_Actions,

--- a/gcc/ada/gen_il-fields.ads
+++ b/gcc/ada/gen_il-fields.ads
@@ -339,6 +339,7 @@ package Gen_IL.Fields is
       Original_Entity,
       Others_Discrete_Choices,
       Out_Present,
+      Parallel_Branches,
       Parameter_Associations,
       Parameter_Specifications,
       Parameter_Type,

--- a/gcc/ada/gen_il-fields.ads
+++ b/gcc/ada/gen_il-fields.ads
@@ -271,6 +271,7 @@ package Gen_IL.Fields is
       Is_Machine_Number,
       Is_Null_Loop,
       Is_Overloaded,
+      Is_Parallel,
       Is_Power_Of_2_For_Shift,
       Is_Preelaborable_Call,
       Is_Prefixed_Call,

--- a/gcc/ada/gen_il-gen-gen_nodes.adb
+++ b/gcc/ada/gen_il-gen-gen_nodes.adb
@@ -913,6 +913,12 @@ begin -- Gen_IL.Gen.Gen_Nodes
         Sm (Is_Initialization_Block, Flag),
         Sm (Is_Task_Master, Flag)));
 
+   Cc (N_Parallel_Branch, Node_Kind,
+       (Sy (Statements, List_Id, Default_Empty_List)));
+
+   Cc (N_Parallel_Block_Statement, N_Statement_Other_Than_Procedure_Call,
+       (Sy (Parallel_Branches, List_Id, Default_No_List)));
+
    Cc (N_Case_Statement, N_Statement_Other_Than_Procedure_Call,
        (Sy (Expression, Node_Id, Default_Empty),
         Sy (Alternatives, List_Id, Default_No_List),

--- a/gcc/ada/gen_il-gen-gen_nodes.adb
+++ b/gcc/ada/gen_il-gen-gen_nodes.adb
@@ -913,11 +913,16 @@ begin -- Gen_IL.Gen.Gen_Nodes
         Sm (Is_Initialization_Block, Flag),
         Sm (Is_Task_Master, Flag)));
 
+   Cc (N_Chunk_Specifier, Node_Kind,
+       (Sy (Identifier, Node_Id, Default_Empty),
+        Sy (Range_Constraint, Node_Id, Default_Empty)));
+
    Cc (N_Parallel_Branch, Node_Kind,
        (Sy (Statements, List_Id, Default_Empty_List)));
 
    Cc (N_Parallel_Block_Statement, N_Statement_Other_Than_Procedure_Call,
-       (Sy (Parallel_Branches, List_Id, Default_No_List)));
+       (Sy (Chunk_Specifier, Node_Id, Default_Empty),
+        Sy (Parallel_Branches, List_Id, Default_No_List)));
 
    Cc (N_Case_Statement, N_Statement_Other_Than_Procedure_Call,
        (Sy (Expression, Node_Id, Default_Empty),

--- a/gcc/ada/gen_il-gen-gen_nodes.adb
+++ b/gcc/ada/gen_il-gen-gen_nodes.adb
@@ -1063,6 +1063,8 @@ begin -- Gen_IL.Gen.Gen_Nodes
        (Sy (Condition, Node_Id, Default_Empty),
         Sy (Iterator_Specification, Node_Id, Default_Empty),
         Sy (Loop_Parameter_Specification, Node_Id, Default_Empty),
+        Sy (Chunk_Specifier, Node_Id, Default_Empty),
+        Sy (Is_Parallel, Flag),
         Sm (Condition_Actions, List_Id)));
 
    Cc (N_Terminate_Alternative, Node_Kind,

--- a/gcc/ada/gen_il-types.ads
+++ b/gcc/ada/gen_il-types.ads
@@ -324,6 +324,8 @@ package Gen_IL.Types is
       N_Assignment_Statement,
       N_Asynchronous_Select,
       N_Block_Statement,
+      N_Parallel_Branch,
+      N_Parallel_Block_Statement,
       N_Case_Statement,
       N_Code_Statement,
       N_Compound_Statement,

--- a/gcc/ada/gen_il-types.ads
+++ b/gcc/ada/gen_il-types.ads
@@ -211,6 +211,7 @@ package Gen_IL.Types is
       N_Identifier,
       N_Operator_Symbol,
       N_Character_Literal,
+      N_Chunk_Specifier,
       N_Op_Add,
       N_Op_Concat,
       N_Op_Expon,

--- a/gcc/ada/par-ch5.adb
+++ b/gcc/ada/par-ch5.adb
@@ -2060,6 +2060,7 @@ package body Ch5 is
       Chunk_Spec : Node_Id := Empty;
    begin
       T_Parallel;
+      Error_Msg_Ada_2022_Feature ("Parallel construct", Token_Ptr);
 
       if Token = Tok_Left_Paren then
          Chunk_Spec := P_Chunk_Specifier;

--- a/gcc/ada/par-ch5.adb
+++ b/gcc/ada/par-ch5.adb
@@ -477,7 +477,7 @@ package body Ch5 is
                      Test_Statement_Required;
                      exit;
 
-                  --  Otherwise complain and skip past and
+                  --  Otherwise complain and skip past AND
 
                   else
                      Error_Msg_SC ("AND not allowed here");
@@ -2069,15 +2069,15 @@ package body Ch5 is
       case Token is
          when Tok_Do =>
             if Present (Loop_Name) then
-               Error_Msg_F ("Loop label not allowed on " &
-                 "parallel do", Loop_Name);
+               Error_Msg_F ("Identifiers cannot be used for " &
+                 "parallel block statements", Loop_Name);
             end if;
 
             if Present (Chunk_Spec) and then
               Nkind (Chunk_Spec) = N_Chunk_Specifier
             then
-               Error_Msg_F ("Range chunk specifier not " &
-                 "allowed for parallel do", Chunk_Spec);
+               Error_Msg_F ("Range chunk specifier not permitted" &
+                 " in parallel block statements", Chunk_Spec);
             end if;
 
             return P_Parallel_Do_Statement (Chunk_Spec);
@@ -2095,7 +2095,8 @@ package body Ch5 is
                return Loop_Node;
             end;
          when others =>
-            Error_Msg_SC ("Invalid token following parallel");
+            Error_Msg_SC ("Invalid token following parallel. " &
+              "Expected AND or FOR.");
             return Error;
       end case;
    end P_Parallel_Construct;

--- a/gcc/ada/par-endh.adb
+++ b/gcc/ada/par-endh.adb
@@ -231,6 +231,10 @@ package body Endh is
             End_Type := E_Select;
             Scan; -- past SELECT
 
+         elsif Token = Tok_Do then
+            End_Type := E_Do;
+            Scan; -- past DO
+
          --  Cases which do allow labels
 
          else
@@ -885,6 +889,9 @@ package body Endh is
       elsif End_Type = E_Select then
          Error_Msg_SC ("no SELECT for this `END SELECT`!");
 
+      elsif End_Type = E_Do then
+         Error_Msg_SC ("no DO for this `END DO`!");
+
       else
          Error_Msg_SC ("no BEGIN for this END!");
       end if;
@@ -987,6 +994,10 @@ package body Endh is
          Error_Msg_SC -- CODEFIX
            ("`END SELECT;` expected@ for SELECT#!");
 
+      elsif End_Type = E_Do then
+         Error_Msg_SC -- CODEFIX
+           ("`END DO;` expected@ for DO#!");
+
       --  All remaining cases are cases with a name (we do not treat the
       --  suspicious is cases specially for a replaced end, only for an
       --  inserted end).
@@ -1057,6 +1068,10 @@ package body Endh is
       elsif End_Type = E_Select then
          Error_Msg_BC
            ("missing `END SELECT;` for SELECT#!");
+
+      elsif End_Type = E_Do then
+         Error_Msg_BC
+           ("missing `END DO;` for DO#!");
 
       elsif End_Type = E_Name then
          if Error_Msg_Node_1 = Empty then

--- a/gcc/ada/par-tchk.adb
+++ b/gcc/ada/par-tchk.adb
@@ -201,6 +201,15 @@ package body Tchk is
       end if;
    end T_Comma;
 
+   ----------
+   -- T_Do --
+   ----------
+
+   procedure T_Do is
+   begin
+      Check_Token (Tok_Do, AP);
+   end T_Do;
+
    ---------------
    -- T_Dot_Dot --
    ---------------
@@ -374,6 +383,15 @@ package body Tchk is
    begin
       Check_Token (Tok_Or, AP);
    end T_Or;
+
+   ----------------
+   -- T_Parallel --
+   ----------------
+
+   procedure T_Parallel is
+   begin
+      Check_Token (Tok_Parallel, AP);
+   end T_Parallel;
 
    ---------------
    -- T_Private --

--- a/gcc/ada/par.adb
+++ b/gcc/ada/par.adb
@@ -407,6 +407,7 @@ function Par (Configuration_Pragmas : Boolean) return List_Id is
       Extm : Boolean;      -- EXCEPTION can terminate sequence
       Fitm : Boolean;      -- FINALLY can terminate sequence
       Ortm : Boolean;      -- OR can terminate sequence
+      Antm : Boolean;      -- AND can terminate sequence
       Sreq : Boolean;      -- at least one statement required
       Tatm : Boolean;      -- THEN ABORT can terminate sequence
       Whtm : Boolean;      -- WHEN can terminate sequence
@@ -414,16 +415,17 @@ function Par (Configuration_Pragmas : Boolean) return List_Id is
    end record;
    pragma Pack (SS_Rec);
 
-   SS_Eftm_Eltm_Sreq : constant SS_Rec := (T, T, F, F, F, T, F, F, F);
-   SS_Eltm_Ortm_Tatm : constant SS_Rec := (F, T, F, F, T, F, T, F, F);
-   SS_Extm_Fitm_Sreq : constant SS_Rec := (F, F, T, T, F, T, F, F, F);
-   SS_None           : constant SS_Rec := (F, F, F, F, F, F, F, F, F);
-   SS_Ortm_Sreq      : constant SS_Rec := (F, F, F, F, T, T, F, F, F);
-   SS_Sreq           : constant SS_Rec := (F, F, F, F, F, T, F, F, F);
-   SS_Sreq_Whtm      : constant SS_Rec := (F, F, F, F, F, T, F, T, F);
-   SS_Sreq_Fitm_Whtm : constant SS_Rec := (F, F, F, T, F, T, F, T, F);
-   SS_Whtm           : constant SS_Rec := (F, F, F, F, F, F, F, T, F);
-   SS_Unco           : constant SS_Rec := (F, F, F, F, F, F, F, F, T);
+   SS_Eftm_Eltm_Sreq : constant SS_Rec := (T, T, F, F, F, F, T, F, F, F);
+   SS_Eltm_Ortm_Tatm : constant SS_Rec := (F, T, F, F, T, F, F, T, F, F);
+   SS_Extm_Fitm_Sreq : constant SS_Rec := (F, F, T, T, F, F, T, F, F, F);
+   SS_None           : constant SS_Rec := (F, F, F, F, F, F, F, F, F, F);
+   SS_Ortm_Sreq      : constant SS_Rec := (F, F, F, F, T, F, T, F, F, F);
+   SS_Antm_Sreq      : constant SS_Rec := (F, F, F, F, F, T, T, F, F, F);
+   SS_Sreq           : constant SS_Rec := (F, F, F, F, F, F, T, F, F, F);
+   SS_Sreq_Whtm      : constant SS_Rec := (F, F, F, F, F, F, T, F, T, F);
+   SS_Sreq_Fitm_Whtm : constant SS_Rec := (F, F, F, T, F, F, T, F, T, F);
+   SS_Whtm           : constant SS_Rec := (F, F, F, F, F, F, F, F, T, F);
+   SS_Unco           : constant SS_Rec := (F, F, F, F, F, F, F, F, F, T);
 
    Goto_List : Elist_Id;
    --  List of goto nodes appearing in the current compilation. Used to
@@ -463,6 +465,7 @@ function Par (Configuration_Pragmas : Boolean) return List_Id is
        E_Record,          -- END RECORD;
        E_Return,          -- END RETURN;
        E_Select,          -- END SELECT;
+       E_Do,              -- END DO;
        E_Name,            -- END [name];
        E_Suspicious_Is,   -- END [name]; (case of suspicious IS)
        E_Bad_Is);         -- END [name]; (case of bad IS)
@@ -1240,6 +1243,7 @@ function Par (Configuration_Pragmas : Boolean) return List_Id is
       procedure T_Colon;
       procedure T_Colon_Equal;
       procedure T_Comma;
+      procedure T_Do;
       procedure T_Dot_Dot;
       procedure T_For;
       procedure T_Greater_Greater;
@@ -1252,6 +1256,7 @@ function Par (Configuration_Pragmas : Boolean) return List_Id is
       procedure T_New;
       procedure T_Of;
       procedure T_Or;
+      procedure T_Parallel;
       procedure T_Private;
       procedure T_Range;
       procedure T_Record;

--- a/gcc/ada/prep.adb
+++ b/gcc/ada/prep.adb
@@ -82,6 +82,7 @@ package body Prep is
       Tok_Others    => Name_Others,
       Tok_Out       => Name_Out,
       Tok_Package   => Name_Package,
+      Tok_Parallel  => Name_Parallel,
       Tok_Pragma    => Name_Pragma,
       Tok_Private   => Name_Private,
       Tok_Procedure => Name_Procedure,

--- a/gcc/ada/scans.adb
+++ b/gcc/ada/scans.adb
@@ -98,6 +98,7 @@ package body Scans is
       Set_Reserved (Name_Others,    Tok_Others);
       Set_Reserved (Name_Out,       Tok_Out);
       Set_Reserved (Name_Package,   Tok_Package);
+      Set_Reserved (Name_Parallel,  Tok_Parallel);
       Set_Reserved (Name_Pragma,    Tok_Pragma);
       Set_Reserved (Name_Private,   Tok_Private);
       Set_Reserved (Name_Procedure, Tok_Procedure);

--- a/gcc/ada/scans.adb
+++ b/gcc/ada/scans.adb
@@ -98,7 +98,6 @@ package body Scans is
       Set_Reserved (Name_Others,    Tok_Others);
       Set_Reserved (Name_Out,       Tok_Out);
       Set_Reserved (Name_Package,   Tok_Package);
-      Set_Reserved (Name_Parallel,  Tok_Parallel);
       Set_Reserved (Name_Pragma,    Tok_Pragma);
       Set_Reserved (Name_Private,   Tok_Private);
       Set_Reserved (Name_Procedure, Tok_Procedure);
@@ -135,6 +134,10 @@ package body Scans is
       --  Ada 2012 reserved words
 
       Set_Reserved (Name_Some, Tok_Some);
+
+      --  Ada 2022 reserved words
+
+      Set_Reserved (Name_Parallel,  Tok_Parallel);
 
       --  GNAT extensions reserved words
       Set_Reserved (Name_Finally, Tok_Finally);

--- a/gcc/ada/scans.ads
+++ b/gcc/ada/scans.ads
@@ -174,6 +174,7 @@ package Scans is
       Tok_Declare,         -- DECLARE      Eterm, Sterm, After_SM, Labeled_Stmt
       Tok_For,             -- FOR          Eterm, Sterm, After_SM, Labeled_Stmt
       Tok_Loop,            -- LOOP         Eterm, Sterm, After_SM, Labeled_Stmt
+      Tok_Parallel,        -- PARALLEL     Eterm, Sterm, After_SM, Labeled_Stmt
       Tok_While,           -- WHILE        Eterm, Sterm, After_SM, Labeled_Stmt
 
       Tok_Entry,           -- ENTRY        Eterm, Sterm, Declk, Deckn, After_SM

--- a/gcc/ada/sem.adb
+++ b/gcc/ada/sem.adb
@@ -60,6 +60,7 @@ with Stylesw;        use Stylesw;
 with Uintp;          use Uintp;
 with Uname;          use Uname;
 
+with Ada.Exceptions;
 with Ada.Unchecked_Deallocation;
 
 pragma Warnings (Off, Sem_Util);
@@ -164,6 +165,16 @@ package body Sem is
 
          when N_Attribute_Definition_Clause   =>
             Analyze_Attribute_Definition_Clause (N);
+
+         when N_Parallel_Branch =>
+            Ada.Exceptions.Raise_Exception
+              (Program_Error'Identity,
+               "N_Parallel_Branch unimplemented");
+
+         when N_Parallel_Block_Statement =>
+            Ada.Exceptions.Raise_Exception
+              (Program_Error'Identity,
+               "N_Parallel_Block_Statement unimplemented");
 
          when N_Block_Statement =>
             Analyze_Block_Statement (N);

--- a/gcc/ada/sem.adb
+++ b/gcc/ada/sem.adb
@@ -166,6 +166,11 @@ package body Sem is
          when N_Attribute_Definition_Clause   =>
             Analyze_Attribute_Definition_Clause (N);
 
+         when N_Chunk_Specifier =>
+            Ada.Exceptions.Raise_Exception
+              (Program_Error'Identity,
+               "N_Chunk_Specifier unimplemented");
+
          when N_Parallel_Branch =>
             Ada.Exceptions.Raise_Exception
               (Program_Error'Identity,

--- a/gcc/ada/sem.adb
+++ b/gcc/ada/sem.adb
@@ -55,6 +55,7 @@ with Sem_Util;       use Sem_Util;
 with Sinfo;          use Sinfo;
 with Sinfo.Nodes;    use Sinfo.Nodes;
 with Sinfo.Utils;    use Sinfo.Utils;
+with Errout;         use Errout;
 with Stand;          use Stand;
 with Stylesw;        use Stylesw;
 with Uintp;          use Uintp;
@@ -167,19 +168,16 @@ package body Sem is
             Analyze_Attribute_Definition_Clause (N);
 
          when N_Chunk_Specifier =>
-            Ada.Exceptions.Raise_Exception
-              (Program_Error'Identity,
-               "N_Chunk_Specifier unimplemented");
+            Error_Msg ("N_Chunk_Specifier" &
+               " unimplemented", Sloc (N));
 
          when N_Parallel_Branch =>
-            Ada.Exceptions.Raise_Exception
-              (Program_Error'Identity,
-               "N_Parallel_Branch unimplemented");
+            Error_Msg ("N_Parallel_Branch" &
+               " unimplemented", Sloc (N));
 
          when N_Parallel_Block_Statement =>
-            Ada.Exceptions.Raise_Exception
-              (Program_Error'Identity,
-               "N_Parallel_Block_Statement unimplemented");
+            Error_Msg ("N_Parallel_Block_Statement" &
+               " unimplemented", Sloc (N));
 
          when N_Block_Statement =>
             Analyze_Block_Statement (N);

--- a/gcc/ada/snames.ads-tmpl
+++ b/gcc/ada/snames.ads-tmpl
@@ -1308,7 +1308,6 @@ package Snames is
    Name_Others                           : constant Name_Id := N + $;
    Name_Out                              : constant Name_Id := N + $;
    Name_Package                          : constant Name_Id := N + $;
-   Name_Parallel                         : constant Name_Id := N + $;
    Name_Pragma                           : constant Name_Id := N + $;
    Name_Private                          : constant Name_Id := N + $;
    Name_Procedure                        : constant Name_Id := N + $;
@@ -1435,6 +1434,14 @@ package Snames is
 
    subtype Ada_2012_Reserved_Words is Name_Id
      range First_2012_Reserved_Word .. Last_2012_Reserved_Word;
+
+   --  Ada 2022 reserved words
+   First_2022_Reserved_Word              : constant Name_Id := N + $;
+   Name_Parallel                         : constant Name_Id := N + $;
+   Last_2022_Reserved_Word               : constant Name_Id := N + $;
+
+   subtype Ada_2022_Reserved_Words is Name_Id
+     range First_2022_Reserved_Word .. Last_2022_Reserved_Word;
 
    --  GNAT extensions reserved words
 

--- a/gcc/ada/snames.ads-tmpl
+++ b/gcc/ada/snames.ads-tmpl
@@ -1308,6 +1308,7 @@ package Snames is
    Name_Others                           : constant Name_Id := N + $;
    Name_Out                              : constant Name_Id := N + $;
    Name_Package                          : constant Name_Id := N + $;
+   Name_Parallel                         : constant Name_Id := N + $;
    Name_Pragma                           : constant Name_Id := N + $;
    Name_Private                          : constant Name_Id := N + $;
    Name_Procedure                        : constant Name_Id := N + $;

--- a/gcc/ada/sprint.adb
+++ b/gcc/ada/sprint.adb
@@ -1249,6 +1249,28 @@ package body Sprint is
             Write_Char (';');
             Sprint_At_End_Proc (Node);
 
+         when N_Parallel_Branch =>
+            Sprint_Indented_List (Statements (Node));
+
+         when N_Parallel_Block_Statement =>
+            Write_Indent_Str_Sloc ("parallel do");
+
+            declare
+               Branch_Node : Node_Id;
+            begin
+               Branch_Node := First (Parallel_Branches (Node));
+               loop
+                  Indent_Begin;
+                  Sprint_Node (Branch_Node);
+                  Indent_End;
+                  Next (Branch_Node);
+                  exit when No (Branch_Node);
+                  Write_Indent_Str ("and");
+               end loop;
+            end;
+
+            Write_Indent_Str ("end do;");
+
          when N_Call_Marker =>
             null;
 

--- a/gcc/ada/sprint.adb
+++ b/gcc/ada/sprint.adb
@@ -1253,7 +1253,15 @@ package body Sprint is
             Sprint_Indented_List (Statements (Node));
 
          when N_Parallel_Block_Statement =>
-            Write_Indent_Str_Sloc ("parallel do");
+            Write_Indent_Str_Sloc ("parallel ");
+
+            if Present (Chunk_Specifier (Node)) then
+               Write_Char ('(');
+               Sprint_Node (Chunk_Specifier (Node));
+               Write_Str (") ");
+            end if;
+
+            Write_Str_Sloc ("do");
 
             declare
                Branch_Node : Node_Id;
@@ -1338,6 +1346,11 @@ package body Sprint is
             Write_Char_Sloc (''');
             Write_Char_Code (UI_To_CC (Char_Literal_Value (Node)));
             Write_Char (''');
+
+         when N_Chunk_Specifier =>
+            Write_Id (Identifier (Node));
+            Write_Str (" in ");
+            Sprint_Node (Range_Constraint (Node));
 
          when N_Code_Statement =>
             Write_Indent;

--- a/gcc/ada/sprint.adb
+++ b/gcc/ada/sprint.adb
@@ -2333,7 +2333,17 @@ package body Sprint is
                Write_Str_With_Col_Check_Sloc ("while ");
                Sprint_Node (Condition (Node));
             else
-               Write_Str_With_Col_Check_Sloc ("for ");
+               if Is_Parallel (Node) then
+                  Write_Str_With_Col_Check_Sloc ("parallel ");
+                  if Present (Chunk_Specifier (Node)) then
+                     Write_Char ('(');
+                     Sprint_Node (Chunk_Specifier (Node));
+                     Write_Str (") ");
+                  end if;
+                  Write_Str ("for ");
+               else
+                  Write_Str_With_Col_Check_Sloc ("for ");
+               end if;
 
                if Present (Iterator_Specification (Node)) then
                   Sprint_Node (Iterator_Specification (Node));


### PR DESCRIPTION
This patch adds the "parallel do" and the "parallel for" syntax to the Ada frontend. The following node types were introduced to represent "parallel do" syntax: `N_Chunk_Specifier`, `N_Parallel_Branch`, and `﻿﻿﻿N_Parallel_Block_Statement`. `N_Iteration_Scheme` was modified to include the `Is_Parallel` and `Chunk_Specifier` properties.

I do have tests that I've run locally for these changes, but I haven't integrated them into the Ada unit test suite because they are not yet apart of ACATs and do not have any runtime behavior.