### PR TITLE
Remove buggy assertion

### DIFF
--- a/gcc/ada/sem_ch6.adb
+++ b/gcc/ada/sem_ch6.adb
@@ -3649,7 +3649,6 @@ package body Sem_Ch6 is
                  Name => New_Occurrence_Of (Get_Return_Ind, Loc),
                  Expression => New_Early_Exit_Case (Post_Call_Action)));
             else
-               pragma Assert (No (Return_Val));
                Append_To (If_Body, Make_Null_Statement (Loc));
             end if;
 


### PR DESCRIPTION
This pull request removes an assertion that isn't always true (`pragma Assert (No (Return_Val))`).  I originally included this assertion because I was thinking of "empty" returns (`return;`) and not statements that exit without returning (e.g. `exit` and `goto`). Take the following example:

```
procedure Loop_Bug is
   function Ret_Val return Integer is
   begin
      Outer: parallel for I in 1 .. 100 loop
         parallel for J in 1 .. 50 loop
            if J = 15 then
               return 20;
            end if;
            if J = 20 then
               exit Outer;
            end if;
         end loop;
      end loop Outer;
      return 0;
   end Ret_Val;
begin
   null;
end Loop_Bug;
```

In this case, the second early exit (`exit Outer`) does not have a return value even though we previously exited the loop with a return value. This pull request fixes this issue.