### PR TITLE
Expansion for parallel array loops

### DIFF
--- a/gcc/ada/einfo.ads
+++ b/gcc/ada/einfo.ads
@@ -3174,7 +3174,8 @@ package Einfo is
 --       points to the array type for which this is the Packed_Array_Impl_Type.
 
 --    Is_Parallel_Loop_Scope
---       Set if this scope is a parallel loop scope.
+--       Set if this scope is a parallel loop scope inside an outlined
+--       procedure.
 
 --    Is_Param_Block_Component_Type [base type only]
 --       Defined in access types. Set to indicate that a type is the type of a

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -5097,11 +5097,12 @@ package body Exp_Ch5 is
       New_Scheme  : Node_Id;
 
       subtype Array_Index is Pos range 1 .. Array_Dim;
-      Index_Types  : array (Array_Index) of Entity_Id;
-      Fortran_Mode : constant Boolean := (Convention (Array_Typ) =
+      Index_Types   : array (Array_Index) of Entity_Id;
+      Row_Major_Ord : constant Boolean := (Convention (Array_Typ) /=
                                            Convention_Fortran);
-      Last_Ind     : constant Pos := (if Fortran_Mode then Array_Index'Last
-                                       else Array_Index'First);
+      Last_Ind      : constant Pos := (if Row_Major_Ord then
+                                       Array_Index'First else
+                                       Array_Index'Last);
 
       procedure Build_Index (I : Array_Index; Last_Base : in out Entity_Id);
       --  Body of the loop that builds the index value for array dimension I.
@@ -5122,7 +5123,7 @@ package body Exp_Ch5 is
          --  dimensions in the array type. To do this, we start with the new
          --  loop parameter and iteratively divide this value by K, where K
          --  is the length of the array dimension we are currently iterating
-         --  over. Each of these quotients are saved into a varaible J. Each
+         --  over. Each of these quotients are saved into a variable J_n. Each
          --  subindex is then given by the modulus of J and K, except for the
          --  last subindex, which is just the previous J value. Each subindex
          --  is then added to its index type's 'First value and cast to its
@@ -5239,10 +5240,10 @@ package body Exp_Ch5 is
                        Expressions    => New_List (
                          Make_Integer_Literal (Loc, I))))))));
 
-         if Fortran_Mode then
-            Append_To (Indices, Index_Value);
-         else
+         if Row_Major_Ord then
             Prepend_To (Indices, Index_Value);
+         else
+            Append_To (Indices, Index_Value);
          end if;
       end Build_Index;
 
@@ -5272,12 +5273,12 @@ package body Exp_Ch5 is
 
       --  Build the index values for our array access
 
-      if Fortran_Mode then
-         for I in 1 .. Array_Dim loop
+      if Row_Major_Ord then
+         for I in reverse 1 .. Array_Dim loop
             Build_Index (I, Last_Base);
          end loop;
       else
-         for I in reverse 1 .. Array_Dim loop
+         for I in 1 .. Array_Dim loop
             Build_Index (I, Last_Base);
          end loop;
       end if;

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -5094,8 +5094,157 @@ package body Exp_Ch5 is
       New_LPS_Id  : constant Entity_Id := Make_Temporary (Loc, 'P');
       Block_Decls : constant List_Id   := New_List;
       Last_Base   : Entity_Id          := New_LPS_Id;
-      Index_Type  : Entity_Id          := First_Index (Array_Typ);
       New_Scheme  : Node_Id;
+
+      subtype Array_Index is Pos range 1 .. Array_Dim;
+      Index_Types  : array (Array_Index) of Entity_Id;
+      Fortran_Mode : constant Boolean := (Convention (Array_Typ) =
+                                           Convention_Fortran);
+      Last_Ind     : constant Pos := (if Fortran_Mode then Array_Index'Last
+                                       else Array_Index'First);
+
+      procedure Build_Index (I : Array_Index; Last_Base : in out Entity_Id);
+      --  Body of the loop that builds the index value for array dimension I.
+      --  We need to move this loop body in its own procedure because the loop
+      --  runs backwards normally and forward when the array type uses Fortran
+      --  convention.
+
+      -----------------
+      -- Build_Index --
+      -----------------
+
+      procedure Build_Index (I : Array_Index; Last_Base : in out Entity_Id) is
+         Base_Index_Type : constant Entity_Id := Etype (Index_Types (I));
+         Current_Ind, Index_Value : Node_Id;
+
+         --  Our goal is to build out a single loop that decomposes an
+         --  index into N different subindices, where N is the number of
+         --  dimensions in the array type. To do this, we start with the new
+         --  loop parameter and iteratively divide this value by K, where K
+         --  is the length of the array dimension we are currently iterating
+         --  over. Each of these quotients are saved into a varaible J. Each
+         --  subindex is then given by the modulus of J and K, except for the
+         --  last subindex, which is just the previous J value. Each subindex
+         --  is then added to its index type's 'First value and cast to its
+         --  appropriate type.
+
+         --  For an array with three dimensions, the expanded code would
+         --  look like:
+
+         --     for New_Param in Low_Arg .. Hi_Arg loop
+         --        declare
+         --           J_1 : constant Longest_Integer :=
+         --             New_Param / Array_Val'Length (1);
+         --           J_2 : constant Longest_Integer :=
+         --             J_1 / Array_Val'Length (2);
+         --           J_3 : constant Longest_Integer :=
+         --             J_2 / Array_Val'Length (3);
+
+         --           Index_1 : constant Ind_Type_1 :=
+         --             Ind_Type_1'Val (J_1 mod Array_Val'Length (1) +
+         --               Ind_Type_1'Pos (Ind_Type_1'First));
+         --           Index_2 : constant Ind_Type_1 :=
+         --             Ind_Type_2'Val (J_2 mod Array_Val'Length (2) +
+         --               Ind_Type_2'Pos (Ind_Type_2'First));
+         --           Index_3 : constant Ind_Type_3 :=
+         --             Ind_Type_3'Val (J_3 + Ind_Type_3'Pos (
+         --               Ind_Type_3'First));
+
+         --           Old_Param : Array_Type renames Array_Val
+         --             (Index_1, Index_2, Index_3);
+         --        begin
+         --           ...
+         --        end;
+         --     end loop;
+
+         --  In the rest of these comments, we will refer to the J_*
+         --  values as "base index values" and the Index_* values as
+         --  "subindex values". This procedure focuses on building a
+         --  single base/subindex pair.
+
+      begin
+         --  If we're at the end of our array, our current index value
+         --  is just the previous base index value.
+
+         if I = Last_Ind then
+            Current_Ind := New_Occurrence_Of (Last_Base, Loc);
+
+         --  Otherwise, we need to compute the next base index value
+         --  as well as its corresponding subindex value.
+
+         else
+            declare
+               --  The current dimension's length:
+
+               --     Array_Val'Length (I)
+
+               Dim_Len      : constant Node_Id :=
+                 Make_Attribute_Reference (Loc,
+                   Prefix         => New_Copy_Tree (Array_Val),
+                   Attribute_Name => Name_Length,
+                   Expressions    => New_List (
+                     Make_Integer_Literal (Loc, I)));
+               Next_Base_Id : constant Entity_Id :=
+                 Make_Temporary (Loc, 'P');
+            begin
+               --  Compute the value for our current base index:
+
+               --     Next_Base := Last_Base / Array_Val'Length (I);
+
+               Append_To (Block_Decls,
+                 Make_Object_Declaration (Loc,
+                   Defining_Identifier => Next_Base_Id,
+                   Constant_Present    => True,
+                   Expression          => Make_Op_Divide (Loc,
+                     Left_Opnd         =>
+                       New_Occurrence_Of (Last_Base, Loc),
+                     Right_Opnd        => Dim_Len),
+                   Object_Definition   =>
+                     New_Occurrence_Of (
+                       RTE (RE_Longest_Integer), Loc)));
+
+               --  Generate:
+
+               --     Last_Base mod Array_Val'Length (I)
+
+               Current_Ind := Make_Op_Mod (Loc,
+                 Left_Opnd  => New_Occurrence_Of (Last_Base, Loc),
+                 Right_Opnd => New_Copy_Tree (Dim_Len));
+
+               Last_Base := Next_Base_Id;
+            end;
+         end if;
+
+         --  Generates current subindex cast to its
+         --  proper type:
+
+         --     Ind_Type'Val (J_1 mod Ind_Type'Length (I) +
+         --       Ind_Type'Pos (Ind_Type'First))
+
+         Index_Value := Make_Attribute_Reference (Loc,
+           Prefix                   =>
+             New_Occurrence_Of (Base_Index_Type, Loc),
+               Attribute_Name           => Name_Val,
+               Expressions              => New_List (Make_Op_Add (Loc,
+               Left_Opnd              => Current_Ind,
+               Right_Opnd             =>
+                 Make_Attribute_Reference (Loc,
+                   Prefix             =>
+                     New_Occurrence_Of (Base_Index_Type, Loc),
+                 Attribute_Name     => Name_Pos,
+                   Expressions        => New_List (
+                     Make_Attribute_Reference (Loc,
+                       Prefix         => New_Copy_Tree (Array_Val),
+                       Attribute_Name => Name_First,
+                       Expressions    => New_List (
+                         Make_Integer_Literal (Loc, I))))))));
+
+         if Fortran_Mode then
+            Append_To (Indices, Index_Value);
+         else
+            Prepend_To (Indices, Index_Value);
+         end if;
+      end Build_Index;
 
    begin
       --  Expand iterator filter
@@ -5109,135 +5258,29 @@ package body Exp_Ch5 is
 
       Set_Debug_Info_Needed (Id);
 
-      --  Our goal is to build out a single loop that decomposes an index
-      --  into N different subindices, where N is the number of dimensions
-      --  in the array type. To do this, we start with the new loop
-      --  parameter and iteratively divide this value by K, where K is the
-      --  length of the array dimension we are currently iterating over.
-      --  Each of these quotients are saved into a varaible J. Each subindex
-      --  is then given by the modulus of J and K, except for the last
-      --  subindex, which is just the previous J value. Each subindex is then
-      --  added to its index type's 'First value and cast to its appropriate
-      --  type.
+      --  Get the type for each index. We need to iterate over these types
+      --  in reverse unless the array uses Fortran convention.
 
-      --  For an array with three dimensions, the expanded code would
-      --  look like:
-
-      --     for New_Param in Low_Arg .. Hi_Arg loop
-      --        declare
-      --           J_1 : constant Longest_Integer :=
-      --             New_Param / Array_Val'Length (1);
-      --           J_2 : constant Longest_Integer :=
-      --             J_1 / Array_Val'Length (2);
-      --           J_3 : constant Longest_Integer :=
-      --             J_2 / Array_Val'Length (3);
-
-      --           Index_1 : constant Ind_Type_1 :=
-      --             Ind_Type_1'Val (J_1 mod Array_Val'Length (1) +
-      --               Ind_Type_1'Pos (Ind_Type_1'First));
-      --           Index_2 : constant Ind_Type_1 :=
-      --             Ind_Type_2'Val (J_2 mod Array_Val'Length (2) +
-      --               Ind_Type_2'Pos (Ind_Type_2'First));
-      --           Index_3 : constant Ind_Type_3 :=
-      --             Ind_Type_3'Val (J_3 + Ind_Type_3'Pos (
-      --               Ind_Type_3'First));
-
-      --           Old_Param : Array_Type renames Array_Val
-      --             (Index_1, Index_2, Index_3);
-      --        begin
-      --           ...
-      --        end;
-      --     end loop;
-
-      --  In the rest of these comments, we will refer to the J_* values
-      --  as "base index values" and the Index_* values as "subindex values"
-
-      for I in 1 .. Array_Dim loop
-         declare
-            Base_Index_Type : constant Entity_Id := Etype (Index_Type);
-            Current_Ind     : Node_Id;
-
-         begin
-            --  If we're at the end of our array, our current index value
-            --  is just the previous base index value.
-
-            if I = Array_Dim then
-               Current_Ind := New_Occurrence_Of (Last_Base, Loc);
-
-            --  Otherwise, we need to compute the next base index value
-            --  as well as its corresponding subindex value.
-
-            else
-               declare
-                  --  The current dimension's length:
-
-                  --     Array_Val'Length (I)
-
-                  Dim_Len      : constant Node_Id :=
-                    Make_Attribute_Reference (Loc,
-                      Prefix         => New_Copy_Tree (Array_Val),
-                      Attribute_Name => Name_Length,
-                      Expressions    => New_List (
-                        Make_Integer_Literal (Loc, I)));
-                  Next_Base_Id : constant Entity_Id :=
-                    Make_Temporary (Loc, 'P');
-               begin
-                  --  Compute the value for our current base index:
-
-                  --     Next_Base := Last_Base / Array_Val'Length (I);
-
-                  Append_To (Block_Decls,
-                    Make_Object_Declaration (Loc,
-                      Defining_Identifier => Next_Base_Id,
-                      Constant_Present    => True,
-                      Expression          => Make_Op_Divide (Loc,
-                        Left_Opnd         =>
-                          New_Occurrence_Of (Last_Base, Loc),
-                        Right_Opnd        => Dim_Len),
-                      Object_Definition   =>
-                        New_Occurrence_Of (
-                          RTE (RE_Longest_Integer), Loc)));
-
-                  --  Generate:
-
-                  --     Last_Base mod Array_Val'Length (I)
-
-                  Current_Ind := Make_Op_Mod (Loc,
-                    Left_Opnd  => New_Occurrence_Of (Last_Base, Loc),
-                    Right_Opnd => New_Copy_Tree (Dim_Len));
-
-                  Last_Base := Next_Base_Id;
-               end;
-            end if;
-
-            --  Generates current subindex cast to its
-            --  proper type:
-
-            --     Ind_Type'Val (J_1 mod Ind_Type'Length (I) +
-            --       Ind_Type'Pos (Ind_Type'First))
-
-            Append_To (Indices,
-              Make_Attribute_Reference (Loc,
-                Prefix                   =>
-                  New_Occurrence_Of (Base_Index_Type, Loc),
-                Attribute_Name           => Name_Val,
-                Expressions              => New_List (Make_Op_Add (Loc,
-                  Left_Opnd              => Current_Ind,
-                  Right_Opnd             =>
-                    Make_Attribute_Reference (Loc,
-                      Prefix             =>
-                        New_Occurrence_Of (Base_Index_Type, Loc),
-                      Attribute_Name     => Name_Pos,
-                      Expressions        => New_List (
-                        Make_Attribute_Reference (Loc,
-                          Prefix         => New_Copy_Tree (Array_Val),
-                          Attribute_Name => Name_First,
-                          Expressions    => New_List (
-                            Make_Integer_Literal (Loc, I)))))))));
-
+      declare
+         Index_Type  : Entity_Id := First_Index (Array_Typ);
+      begin
+         for I in 1 .. Array_Dim loop
+            Index_Types (I) := Index_Type;
             Next_Index (Index_Type);
-         end;
-      end loop;
+         end loop;
+      end;
+
+      --  Build the index values for our array access
+
+      if Fortran_Mode then
+         for I in 1 .. Array_Dim loop
+            Build_Index (I, Last_Base);
+         end loop;
+      else
+         for I in reverse 1 .. Array_Dim loop
+            Build_Index (I, Last_Base);
+         end loop;
+      end if;
 
       --  Generate:
 

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -5154,15 +5154,8 @@ package body Exp_Ch5 is
 
       for I in 1 .. Array_Dim loop
          declare
-            --  The value of our current subindex
-
-            Current_Ind : Node_Id;
-
-            --  TODO: will this always be a N_Subtype_Indication?
-            --  UPDATE: it can also be N_Range (somehow)
-            Base_Index_Type : constant Entity_Id :=
-              (if Nkind (Index_Type) = N_Subtype_Indication then
-               Etype (Subtype_Mark (Index_Type)) else Index_Type);
+            Base_Index_Type : constant Entity_Id := Etype (Index_Type);
+            Current_Ind     : Node_Id;
 
          begin
             --  If we're at the end of our array, our current index value

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -5260,7 +5260,7 @@ package body Exp_Ch5 is
             Component_Type (Array_Typ), Loc),
           Name                =>
             Make_Indexed_Component (Loc,
-              Prefix          => New_Copy_Tree (Array_Val),
+              Prefix          => Relocate_Node (Array_Val),
               Expressions     => Indices)));
 
       --  Generate:

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -5185,7 +5185,7 @@ package body Exp_Ch5 is
                     Declarations               => Block_Decls,
                     Handled_Statement_Sequence =>
                       Make_Handled_Sequence_Of_Statements (Loc,
-                        Statements             => Statements (N)))),
+                        Statements             => Stats))),
                 End_Label                      => End_Label (N)));
             Analyze (N);
          end;
@@ -6043,7 +6043,7 @@ package body Exp_Ch5 is
                Analyze_List (Statements (N));
             end if;
 
-            --  Transform parallel loop discrete subtype
+            --  Transform parallel loop param
 
             if In_Outlined_Parallel (N) then
                Expand_Parallel_Loop_Param (N);
@@ -6397,9 +6397,6 @@ package body Exp_Ch5 is
                  Object_Definition   => New_Occurrence_Of
                    (Etype (Ident), Loc)));
 
-               --  Replace old chunk index variable with new constant
-
-               Remove_Homonym (Ident);
                Mutate_Ekind (Ident, E_Constant);
             end;
          end if;
@@ -6440,7 +6437,7 @@ package body Exp_Ch5 is
                    Expression          => Lower,
                    Object_Definition   => New_Occurrence_Of
                      (Etype (Ident), Loc)));
-               Remove_Homonym (Ident);
+
                Mutate_Ekind (Ident, E_Constant);
             end;
 

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -184,6 +184,9 @@ package body Exp_Ch5 is
    --  Expand parallel loops that use the form "for X of C" to iterate over
    --  arrays (just arrays for now).
 
+   procedure Expand_Parallel_Array_Loop (N : Node_Id);
+   --  Expand parallel iteration over arrays
+
    procedure Expand_Iterator_Loop_Over_Container
      (N             : Node_Id;
       I_Spec        : Node_Id;
@@ -5053,21 +5056,50 @@ package body Exp_Ch5 is
       pragma Assert (In_Outlined_Parallel (N));
       pragma Assert (Present (Iterator_Specification (Scheme)));
 
-      I_Spec : constant Node_Id := Iterator_Specification (Scheme);
-      pragma Assert (Of_Present (I_Spec));
-
+      I_Spec        : constant Node_Id   := Iterator_Specification (Scheme);
       Container     : constant Node_Id   := Name (I_Spec);
       Container_Typ : constant Entity_Id := Base_Type (Etype (Container));
 
+   begin
+      if Is_Array_Type (Container_Typ) then
+         Expand_Parallel_Array_Loop (N);
+
+      --  Unsupported iterator expansion
+
+      else
+         raise Program_Error;
+      end if;
+   end Expand_Parallel_Iterator_Loop;
+
+   --------------------------------
+   -- Expand_Parallel_Array_Loop --
+   --------------------------------
+
+   procedure Expand_Parallel_Array_Loop (N : Node_Id) is
+      Scheme : constant Node_Id    := Iteration_Scheme (N);
+      Loc    : constant Source_Ptr := Sloc (N);
+      I_Spec : constant Node_Id    := Iterator_Specification (Scheme);
+      pragma Assert (Of_Present (I_Spec));
+
+      Array_Val : constant Node_Id   := Name (I_Spec);
+      Array_Typ : constant Entity_Id := Base_Type (Etype (Array_Val));
       Low_Param : constant Entity_Id := Parallel_Low_Bound (N);
       Hi_Param  : constant Entity_Id := Parallel_Hi_Bound (N);
       Id        : constant Entity_Id := Defining_Identifier (I_Spec);
+      Stats     : List_Id := Statements (N);
+      pragma Assert (Is_Array_Type (Array_Typ));
 
-      Stats : List_Id := Statements (N);
-
-      --  TODO: comments
+      Array_Dim   : constant Pos       := Number_Dimensions (Array_Typ);
+      Indices     : constant List_Id   := New_List;
+      New_LPS_Id  : constant Entity_Id := Make_Temporary (Loc, 'P');
+      Block_Decls : constant List_Id   := New_List;
+      Last_Base   : Entity_Id          := New_LPS_Id;
+      Index_Type  : Entity_Id          := First_Index (Array_Typ);
+      New_Scheme  : Node_Id;
 
    begin
+      --  Expand iterator filter
+
       if Present (Iterator_Filter (I_Spec)) then
          pragma Assert (Ada_Version >= Ada_2022);
          Stats := New_List (Make_If_Statement (Loc,
@@ -5075,122 +5107,199 @@ package body Exp_Ch5 is
            Then_Statements => Stats));
       end if;
 
-      if Is_Array_Type (Container_Typ) then
+      Set_Debug_Info_Needed (Id);
+
+      --  Our goal is to build out a single loop that decomposes an index
+      --  into N different subindices, where N is the number of dimensions
+      --  in the array type. To do this, we start with the new loop
+      --  parameter and iteratively divide this value by K, where K is the
+      --  length of the array dimension we are currently iterating over.
+      --  Each of these quotients are saved into a varaible J. Each subindex
+      --  is then given by the modulus of J and K, except for the last
+      --  subindex, which is just the previous J value. Each subindex is then
+      --  added to its index type's 'First value and cast to its appropriate
+      --  type.
+
+      --  For an array with three dimensions, the expanded code would
+      --  look like:
+
+      --     for New_Param in Low_Arg .. Hi_Arg loop
+      --        declare
+      --           J_1 : constant Longest_Integer :=
+      --             New_Param / Array_Val'Length (1);
+      --           J_2 : constant Longest_Integer :=
+      --             J_1 / Array_Val'Length (2);
+      --           J_3 : constant Longest_Integer :=
+      --             J_2 / Array_Val'Length (3);
+
+      --           Index_1 : constant Ind_Type_1 :=
+      --             Ind_Type_1'Val (J_1 mod Array_Val'Length (1) +
+      --               Ind_Type_1'Pos (Ind_Type_1'First));
+      --           Index_2 : constant Ind_Type_1 :=
+      --             Ind_Type_2'Val (J_2 mod Array_Val'Length (2) +
+      --               Ind_Type_2'Pos (Ind_Type_2'First));
+      --           Index_3 : constant Ind_Type_3 :=
+      --             Ind_Type_3'Val (J_3 + Ind_Type_3'Pos (
+      --               Ind_Type_3'First));
+
+      --           Old_Param : Array_Type renames Array_Val
+      --             (Index_1, Index_2, Index_3);
+      --        begin
+      --           ...
+      --        end;
+      --     end loop;
+
+      --  In the rest of these comments, we will refer to the J_* values
+      --  as "base index values" and the Index_* values as "subindex values"
+
+      for I in 1 .. Array_Dim loop
          declare
-            Array_Dim   : constant Pos := Number_Dimensions (Container_Typ);
-            Indices     : constant List_Id := New_List;
-            New_LPS_Id  : constant Entity_Id := Make_Temporary (Loc, 'P');
-            Block_Decls : constant List_Id := New_List;
-            New_Scheme  : Node_Id;
-            Last_Base   : Entity_Id := New_LPS_Id;
-            Index_Type  : Entity_Id := First_Index (Container_Typ);
+            --  The value of our current subindex
+
+            Current_Ind : Node_Id;
+
+            --  TODO: will this always be a N_Subtype_Indication?
+            --  UPDATE: it can also be N_Range (somehow)
+            Base_Index_Type : constant Entity_Id :=
+              (if Nkind (Index_Type) = N_Subtype_Indication then
+               Etype (Subtype_Mark (Index_Type)) else Index_Type);
 
          begin
-            Set_Debug_Info_Needed (Id);
+            --  If we're at the end of our array, our current index value
+            --  is just the previous base index value.
 
-            for I in 1 .. Array_Dim loop
+            if I = Array_Dim then
+               Current_Ind := New_Occurrence_Of (Last_Base, Loc);
+
+            --  Otherwise, we need to compute the next base index value
+            --  as well as its corresponding subindex value.
+
+            else
                declare
-                  Current_Ind : Node_Id;
+                  --  The current dimension's length:
 
-                  --  TODO: will this always be a N_Subtype_Indication?
-                  --  UPDATE: it can also be N_Range (somehow)
-                  Base_Index_Type : constant Entity_Id :=
-                    (if Nkind (Index_Type) = N_Subtype_Indication then
-                     Etype (Subtype_Mark (Index_Type)) else Index_Type);
+                  --     Array_Val'Length (I)
 
-                  Dim_First : constant Node_Id :=
+                  Dim_Len      : constant Node_Id :=
                     Make_Attribute_Reference (Loc,
-                      Prefix         => New_Copy_Tree (Container),
-                      Attribute_Name => Name_First,
+                      Prefix         => New_Copy_Tree (Array_Val),
+                      Attribute_Name => Name_Length,
                       Expressions    => New_List (
                         Make_Integer_Literal (Loc, I)));
-
-                  First_Ind : constant Node_Id :=
-                    Make_Attribute_Reference (Loc,
-                      Prefix => New_Occurrence_Of (Base_Index_Type, Loc),
-                      Attribute_Name => Name_Pos,
-                      Expressions => New_List (Dim_First));
+                  Next_Base_Id : constant Entity_Id :=
+                    Make_Temporary (Loc, 'P');
                begin
-                  if I = Array_Dim then
-                     Current_Ind := New_Occurrence_Of (Last_Base, Loc);
-                  else
-                     declare
-                        Dim_Len : constant Node_Id :=
-                        Make_Attribute_Reference (Loc,
-                          Prefix         => New_Copy_Tree (Container),
-                          Attribute_Name => Name_Length,
-                          Expressions    => New_List (
-                            Make_Integer_Literal (Loc, I)));
+                  --  Compute the value for our current base index:
 
-                        Next_Base_Id : constant Entity_Id :=
-                          Make_Temporary (Loc, 'P');
-                     begin
-                        Append_To (Block_Decls, 
-                          Make_Object_Declaration (Loc,
-                            Defining_Identifier => Next_Base_Id,
-                            Constant_Present => True,
-                            Expression => Make_Op_Divide (Loc,
-                              Left_Opnd => New_Occurrence_Of (Last_Base, Loc),
-                              Right_Opnd => Dim_Len),
-                            Object_Definition =>
-                              New_Occurrence_Of (RTE (RE_Longest_Integer), Loc)));
+                  --     Next_Base := Last_Base / Array_Val'Length (I);
 
-                        Current_Ind := Make_Op_Mod (Loc,
-                          Left_Opnd  => New_Occurrence_Of (Last_Base, Loc),
-                          Right_Opnd => New_Copy_Tree (Dim_Len));
+                  Append_To (Block_Decls,
+                    Make_Object_Declaration (Loc,
+                      Defining_Identifier => Next_Base_Id,
+                      Constant_Present    => True,
+                      Expression          => Make_Op_Divide (Loc,
+                        Left_Opnd         =>
+                          New_Occurrence_Of (Last_Base, Loc),
+                        Right_Opnd        => Dim_Len),
+                      Object_Definition   =>
+                        New_Occurrence_Of (
+                          RTE (RE_Longest_Integer), Loc)));
 
-                        Last_Base := Next_Base_Id;
-                     end;
-                  end if;
+                  --  Generate:
 
-                  Append_To (Indices,
-                    Make_Attribute_Reference (Loc,
-                      Prefix         => New_Occurrence_Of (Base_Index_Type, Loc),
-                      Attribute_Name => Name_Val,
-                      Expressions    => New_List (Make_Op_Add (Loc,
-                        Left_Opnd    => Current_Ind,
-                        Right_Opnd   => First_Ind))));
+                  --     Last_Base mod Array_Val'Length (I)
 
-                  Next_Index (Index_Type);
+                  Current_Ind := Make_Op_Mod (Loc,
+                    Left_Opnd  => New_Occurrence_Of (Last_Base, Loc),
+                    Right_Opnd => New_Copy_Tree (Dim_Len));
+
+                  Last_Base := Next_Base_Id;
                end;
-            end loop;
+            end if;
 
-            Append_To (Block_Decls,
-              Make_Object_Renaming_Declaration (Loc,
-                Defining_Identifier => Id,
-                Subtype_Mark        => New_Occurrence_Of (
-                  Component_Type (Container_Typ), Loc),
-                Name                =>
-                  Make_Indexed_Component (Loc,
-                    Prefix          => New_Copy_Tree (Container),
-                    Expressions     => Indices)));
+            --  Generates current subindex cast to its
+            --  proper type:
 
-            New_Scheme := Make_Iteration_Scheme (Loc,
-              Loop_Parameter_Specification    =>
-                Make_Loop_Parameter_Specification (Loc,
-                  Defining_Identifier         => New_LPS_Id,
-                  Discrete_Subtype_Definition =>
-                    Make_Range (Loc,
-                      Low_Bound               =>
-                        New_Occurrence_Of (Low_Param, Loc),
-                      High_Bound              =>
-                        New_Occurrence_Of (Hi_Param, Loc))));
+            --     Ind_Type'Val (J_1 mod Ind_Type'Length (I) +
+            --       Ind_Type'Pos (Ind_Type'First))
 
-            Rewrite (N,
-              Make_Loop_Statement (Loc,
-                Identifier                     => Identifier (N),
-                Iteration_Scheme               => New_Scheme,
-                Statements                     => New_List (
-                  Make_Block_Statement (Loc,
-                    Declarations               => Block_Decls,
-                    Handled_Statement_Sequence =>
-                      Make_Handled_Sequence_Of_Statements (Loc,
-                        Statements             => Stats))),
-                End_Label                      => End_Label (N)));
-            Analyze (N);
+            Append_To (Indices,
+              Make_Attribute_Reference (Loc,
+                Prefix                   =>
+                  New_Occurrence_Of (Base_Index_Type, Loc),
+                Attribute_Name           => Name_Val,
+                Expressions              => New_List (Make_Op_Add (Loc,
+                  Left_Opnd              => Current_Ind,
+                  Right_Opnd             =>
+                    Make_Attribute_Reference (Loc,
+                      Prefix             =>
+                        New_Occurrence_Of (Base_Index_Type, Loc),
+                      Attribute_Name     => Name_Pos,
+                      Expressions        => New_List (
+                        Make_Attribute_Reference (Loc,
+                          Prefix         => New_Copy_Tree (Array_Val),
+                          Attribute_Name => Name_First,
+                          Expressions    => New_List (
+                            Make_Integer_Literal (Loc, I)))))))));
+
+            Next_Index (Index_Type);
          end;
-      end if;
-   end Expand_Parallel_Iterator_Loop;
+      end loop;
+
+      --  Generate:
+
+      --     declare
+      --        Base_Index_1 : constant Longest_Integer := ...;
+      --        ...
+      --        Old_Param : Old_Type renames Array_Val
+      --          (Index_1, ...);
+      --     begin
+      --        ...
+      --     end;
+
+      --  This block contains our base index definitions as well as our
+      --  loop parameter renaming.
+
+      Append_To (Block_Decls,
+        Make_Object_Renaming_Declaration (Loc,
+          Defining_Identifier => Id,
+          Subtype_Mark        => New_Occurrence_Of (
+            Component_Type (Array_Typ), Loc),
+          Name                =>
+            Make_Indexed_Component (Loc,
+              Prefix          => New_Copy_Tree (Array_Val),
+              Expressions     => Indices)));
+
+      --  Generate:
+
+      --     for New_Param in Low_Arg .. Hi_Arg loop
+      --        ...
+      --     end loop;
+
+      New_Scheme := Make_Iteration_Scheme (Loc,
+        Loop_Parameter_Specification    =>
+          Make_Loop_Parameter_Specification (Loc,
+            Defining_Identifier         => New_LPS_Id,
+            Discrete_Subtype_Definition =>
+              Make_Range (Loc,
+                Low_Bound               =>
+                  New_Occurrence_Of (Low_Param, Loc),
+                High_Bound              =>
+                  New_Occurrence_Of (Hi_Param, Loc))));
+
+      Rewrite (N,
+        Make_Loop_Statement (Loc,
+          Identifier                     => Identifier (N),
+          Iteration_Scheme               => New_Scheme,
+          Statements                     => New_List (
+            Make_Block_Statement (Loc,
+              Declarations               => Block_Decls,
+              Handled_Statement_Sequence =>
+                Make_Handled_Sequence_Of_Statements (Loc,
+                  Statements             => Stats))),
+          End_Label                      => End_Label (N)));
+      Analyze (N);
+   end Expand_Parallel_Array_Loop;
 
    -------------------------------------
    -- Expand_Iterator_Loop_Over_Array --

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -180,6 +180,10 @@ package body Exp_Ch5 is
    --  Expand loop over arrays and containers that uses the form "for X of C"
    --  with an optional subtype mark, or "for Y in C".
 
+   procedure Expand_Parallel_Iterator_Loop (N : Node_Id);
+   --  Expand parallel loops that use the form "for X of C" to iterate over
+   --  arrays (just arrays for now).
+
    procedure Expand_Iterator_Loop_Over_Container
      (N             : Node_Id;
       I_Spec        : Node_Id;
@@ -5042,6 +5046,152 @@ package body Exp_Ch5 is
       end if;
    end Expand_Iterator_Loop;
 
+   procedure Expand_Parallel_Iterator_Loop (N : Node_Id) is
+      Scheme : constant Node_Id    := Iteration_Scheme (N);
+      Loc    : constant Source_Ptr := Sloc (N);
+
+      pragma Assert (In_Outlined_Parallel (N));
+      pragma Assert (Present (Iterator_Specification (Scheme)));
+
+      I_Spec : constant Node_Id := Iterator_Specification (Scheme);
+      pragma Assert (Of_Present (I_Spec));
+
+      Container     : constant Node_Id   := Name (I_Spec);
+      Container_Typ : constant Entity_Id := Base_Type (Etype (Container));
+
+      Low_Param : constant Entity_Id := Parallel_Low_Bound (N);
+      Hi_Param  : constant Entity_Id := Parallel_Hi_Bound (N);
+      Id        : constant Entity_Id := Defining_Identifier (I_Spec);
+
+      Stats : List_Id := Statements (N);
+
+      --  TODO: comments
+
+   begin
+      if Present (Iterator_Filter (I_Spec)) then
+         pragma Assert (Ada_Version >= Ada_2022);
+         Stats := New_List (Make_If_Statement (Loc,
+           Condition => Iterator_Filter (I_Spec),
+           Then_Statements => Stats));
+      end if;
+
+      if Is_Array_Type (Container_Typ) then
+         declare
+            Array_Dim   : constant Pos := Number_Dimensions (Container_Typ);
+            Indices     : constant List_Id := New_List;
+            New_LPS_Id  : constant Entity_Id := Make_Temporary (Loc, 'P');
+            Block_Decls : constant List_Id := New_List;
+            New_Scheme  : Node_Id;
+            Last_Base   : Entity_Id := New_LPS_Id;
+            Index_Type  : Entity_Id := First_Index (Container_Typ);
+
+         begin
+            Set_Debug_Info_Needed (Id);
+
+            for I in 1 .. Array_Dim loop
+               declare
+                  Current_Ind : Node_Id;
+
+                  --  TODO: will this always be a N_Subtype_Indication?
+                  --  UPDATE: it can also be N_Range (somehow)
+                  Base_Index_Type : constant Entity_Id :=
+                    (if Nkind (Index_Type) = N_Subtype_Indication then
+                     Etype (Subtype_Mark (Index_Type)) else Index_Type);
+
+                  Dim_First : constant Node_Id :=
+                    Make_Attribute_Reference (Loc,
+                      Prefix         => New_Copy_Tree (Container),
+                      Attribute_Name => Name_First,
+                      Expressions    => New_List (
+                        Make_Integer_Literal (Loc, I)));
+
+                  First_Ind : constant Node_Id :=
+                    Make_Attribute_Reference (Loc,
+                      Prefix => New_Occurrence_Of (Base_Index_Type, Loc),
+                      Attribute_Name => Name_Pos,
+                      Expressions => New_List (Dim_First));
+               begin
+                  if I = Array_Dim then
+                     Current_Ind := New_Occurrence_Of (Last_Base, Loc);
+                  else
+                     declare
+                        Dim_Len : constant Node_Id :=
+                        Make_Attribute_Reference (Loc,
+                          Prefix         => New_Copy_Tree (Container),
+                          Attribute_Name => Name_Length,
+                          Expressions    => New_List (
+                            Make_Integer_Literal (Loc, I)));
+
+                        Next_Base_Id : constant Entity_Id :=
+                          Make_Temporary (Loc, 'P');
+                     begin
+                        Append_To (Block_Decls, 
+                          Make_Object_Declaration (Loc,
+                            Defining_Identifier => Next_Base_Id,
+                            Constant_Present => True,
+                            Expression => Make_Op_Divide (Loc,
+                              Left_Opnd => New_Occurrence_Of (Last_Base, Loc),
+                              Right_Opnd => Dim_Len),
+                            Object_Definition =>
+                              New_Occurrence_Of (RTE (RE_Longest_Integer), Loc)));
+
+                        Current_Ind := Make_Op_Mod (Loc,
+                          Left_Opnd  => New_Occurrence_Of (Last_Base, Loc),
+                          Right_Opnd => New_Copy_Tree (Dim_Len));
+
+                        Last_Base := Next_Base_Id;
+                     end;
+                  end if;
+
+                  Append_To (Indices,
+                    Make_Attribute_Reference (Loc,
+                      Prefix         => New_Occurrence_Of (Base_Index_Type, Loc),
+                      Attribute_Name => Name_Val,
+                      Expressions    => New_List (Make_Op_Add (Loc,
+                        Left_Opnd    => Current_Ind,
+                        Right_Opnd   => First_Ind))));
+
+                  Next_Index (Index_Type);
+               end;
+            end loop;
+
+            Append_To (Block_Decls,
+              Make_Object_Renaming_Declaration (Loc,
+                Defining_Identifier => Id,
+                Subtype_Mark        => New_Occurrence_Of (
+                  Component_Type (Container_Typ), Loc),
+                Name                =>
+                  Make_Indexed_Component (Loc,
+                    Prefix          => New_Copy_Tree (Container),
+                    Expressions     => Indices)));
+
+            New_Scheme := Make_Iteration_Scheme (Loc,
+              Loop_Parameter_Specification    =>
+                Make_Loop_Parameter_Specification (Loc,
+                  Defining_Identifier         => New_LPS_Id,
+                  Discrete_Subtype_Definition =>
+                    Make_Range (Loc,
+                      Low_Bound               =>
+                        New_Occurrence_Of (Low_Param, Loc),
+                      High_Bound              =>
+                        New_Occurrence_Of (Hi_Param, Loc))));
+
+            Rewrite (N,
+              Make_Loop_Statement (Loc,
+                Identifier                     => Identifier (N),
+                Iteration_Scheme               => New_Scheme,
+                Statements                     => New_List (
+                  Make_Block_Statement (Loc,
+                    Declarations               => Block_Decls,
+                    Handled_Statement_Sequence =>
+                      Make_Handled_Sequence_Of_Statements (Loc,
+                        Statements             => Statements (N)))),
+                End_Label                      => End_Label (N)));
+            Analyze (N);
+         end;
+      end if;
+   end Expand_Parallel_Iterator_Loop;
+
    -------------------------------------
    -- Expand_Iterator_Loop_Over_Array --
    -------------------------------------
@@ -6097,7 +6247,11 @@ package body Exp_Ch5 is
       --  Here to deal with iterator case
 
       elsif Present (Iterator_Specification (Scheme)) then
-         Expand_Iterator_Loop (N);
+         if In_Outlined_Parallel (N) then
+            Expand_Parallel_Iterator_Loop (N);
+         else
+            Expand_Iterator_Loop (N);
+         end if;
 
          --  An iterator loop may generate renaming declarations for elements
          --  that require debug information. This is the case in particular

--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -196,6 +196,10 @@ package body Exp_Ch5 is
    procedure Expand_Parallel_Chunk_Specification (N : Node_Id);
    --  Expand parallel chunk specification
 
+   procedure Expand_Parallel_Loop_Param (N : Node_Id);
+   --  Rewrites discrete subtype definition for loop parameter as
+   --  a range over Outlined_Low_Param .. Outlined_Hi_Param.
+
    procedure Expand_Predicated_Loop (N : Node_Id);
    --  Expand for loop over predicated subtype
 
@@ -5844,6 +5848,8 @@ package body Exp_Ch5 is
          Adjust_Condition (Condition (Scheme));
       end if;
 
+      Expand_Parallel_Chunk_Specification (N);
+
       --  Nothing more to do for plain loop with no iteration scheme
 
       if No (Scheme) then
@@ -5887,9 +5893,14 @@ package body Exp_Ch5 is
                Analyze_List (Statements (N));
             end if;
 
+            --  Transform parallel loop discrete subtype
+
+            if In_Outlined_Parallel (N) then
+               Expand_Parallel_Loop_Param (N);
+
             --  Deal with loop over predicates
 
-            if Is_Discrete_Type (Ltype)
+            elsif Is_Discrete_Type (Ltype)
               and then Present (Predicate_Function (Ltype))
             then
                Expand_Predicated_Loop (N);
@@ -6114,7 +6125,6 @@ package body Exp_Ch5 is
       end if;
 
       Process_Statements_For_Controlled_Objects (Stmt);
-      Expand_Parallel_Chunk_Specification (N);
    end Expand_N_Loop_Statement;
 
    --------------------------------
@@ -6316,6 +6326,81 @@ package body Exp_Ch5 is
       Set_Chunk_Specification (Scheme, Empty);
       Set_Is_Parallel (Scheme, False);
    end Expand_Parallel_Chunk_Specification;
+
+   -------------------------------------
+   -- Expand_Parallel_Iteration_Range --
+   -------------------------------------
+
+   procedure Expand_Parallel_Loop_Param (N : Node_Id) is
+      Loc    : constant Source_Ptr := Sloc (N);
+      Scheme : constant Node_Id    := Iteration_Scheme (N);
+
+      pragma Assert (In_Outlined_Parallel (N));
+      pragma Assert (Present (Loop_Parameter_Specification (Scheme)));
+
+      Loop_Param : constant Node_Id := Loop_Parameter_Specification
+                                         (Scheme);
+      DS         : constant Node_Id := Discrete_Subtype_Definition
+                                         (Loop_Param);
+
+      Ident     : constant Entity_Id := Defining_Identifier (Loop_Param);
+      Low_Param : constant Entity_Id := Parallel_Low_Bound (N);
+      Hi_Param  : constant Entity_Id := Parallel_Hi_Bound (N);
+      New_Id    : constant Entity_Id := Make_Temporary (Loc, 'P');
+
+      New_Loop, New_Scheme, New_Body,
+        New_Loop_Param, Param_Def : Node_Id;
+   begin
+      --  Rewrite discrete subtype as range over Low_Param .. Hi_Param
+
+      New_Loop_Param := Make_Loop_Parameter_Specification (Loc,
+        Defining_Identifier         => New_Id,
+        Discrete_Subtype_Definition => Make_Range (Loc,
+          Low_Bound                 => New_Occurrence_Of (Low_Param, Loc),
+          High_Bound                => New_Occurrence_Of (Hi_Param, Loc)));
+
+      New_Scheme := Make_Iteration_Scheme (Loc,
+        Loop_Parameter_Specification => New_Loop_Param);
+
+      --  Rewrite loop body so that the new loop parameter is
+      --  converted to the original loop's type:
+
+      --     for New_Param in Low_Param .. Hi_Param loop
+      --        declare
+      --           Orig_Param : constant Orig_Type :=
+      --             Orig_Type'Val (New_Param);
+      --        begin
+      --           <LOOP BODY>
+      --        end;
+      --     end loop;
+
+      Param_Def := Make_Object_Declaration (Loc,
+        Defining_Identifier => Ident,
+        Object_Definition   => New_Occurrence_Of (Etype (Ident), Loc),
+        Expression          => Make_Attribute_Reference (Loc,
+          Prefix            => New_Occurrence_Of (Etype (Ident), Loc),
+          Attribute_Name    => Name_Val,
+          Expressions       => New_List (New_Occurrence_Of (New_Id, Loc))),
+        Constant_Present    => True);
+
+      New_Body := Make_Block_Statement (Loc,
+        Declarations               => New_List (Param_Def),
+        Handled_Statement_Sequence =>
+          Make_Handled_Sequence_Of_Statements (Loc,
+            Statements             => Statements (N)));
+
+      New_Loop := Make_Loop_Statement (Loc,
+        Identifier       => Identifier (N),
+        Iteration_Scheme => New_Scheme,
+        Statements       => New_List (New_Body),
+        End_Label        => End_Label (N));
+
+      Rewrite (N, New_Loop);
+      Analyze (N);
+
+      Remove_Homonym (Ident);
+      Mutate_Ekind (Ident, E_Constant);
+   end Expand_Parallel_Loop_Param;
 
    ----------------------------
    -- Expand_Predicated_Loop --

--- a/gcc/ada/gen_il-gen-gen_nodes.adb
+++ b/gcc/ada/gen_il-gen-gen_nodes.adb
@@ -988,6 +988,8 @@ begin -- Gen_IL.Gen.Gen_Nodes
         Sy (Suppress_Loop_Warnings, Flag),
         Sy (Parallel_Declarations, List_Id, Default_No_List),
         Sm (Parallel_Chunk_Id, Node_Id),
+        Sm (Parallel_Low_Bound, Node_Id),
+        Sm (Parallel_Hi_Bound, Node_Id),
         Sm (In_Outlined_Parallel, Flag)));
 
    Ab (N_Loop_Flow_Statement, N_Statement_Other_Than_Procedure_Call,

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -3375,9 +3375,28 @@ package body Sem_Ch5 is
          --  Wrap parallel loop inside outlined procedure
          --  If Stop_Processing is set to True, should stop further processing.
 
-         procedure Outline_Loop;
-         pragma Inline (Outline_Loop);
-         --  Wrap parallel loop inside an outlined procedure
+         procedure Prepare_Parallel_Loop_Param
+           (P : Node_Id; Lo : out Node_Id;
+            Hi : out Node_Id; Typ : out Entity_Id);
+         pragma Inline (Prepare_Parallel_Loop_Param);
+         --  Prepares loop parameter P by moving any calls into the
+         --  enclosing block. Low and high values are written to Lo
+         --  and Hi respectively.
+
+         procedure Create_Par_Range_Loop
+           (Low_Val : Node_Id; Hi_Val : Node_Id);
+         pragma Inline (Create_Par_Range_Loop);
+         --  Moves the loop into an outlined procedure and passes said
+         --  procedure to a Par_Range_Loop_With_Early_Exit call. Low_Val
+         --  and Hi_Val are the range values passed to
+         --  Par_Range_Loop_With_Early_Exit. The generated function has
+         --  the following signature:
+
+         --     procedure Outlined_Proc
+         --       (Low_Arg : Longest_Integer;
+         --        Hi_Arg : Longest_Integer;
+         --        Chunk : Positive;
+         --        Loop_Id : Par_Loop_Id);
 
          procedure Wrap_Loop_Statement (Manage_Sec_Stack : Boolean);
          pragma Inline (Wrap_Loop_Statement);
@@ -3644,16 +3663,222 @@ package body Sem_Ch5 is
             end if;
          end Prepare_Param_Spec_Loop;
 
-         ------------------
-         -- Outline_Loop --
-         ------------------
+         ---------------------------------
+         -- Prepare_Parallel_Loop_Param --
+         ---------------------------------
 
-         procedure Outline_Loop is
+         procedure Prepare_Parallel_Loop_Param
+           (P : Node_Id; Lo : out Node_Id;
+            Hi : out Node_Id; Typ : out Entity_Id)
+         is
+            pragma Assert (Nkind (P) in
+              N_Loop_Parameter_Specification | N_Chunk_Specification_Range);
+            DS     : constant Node_Id    := Discrete_Subtype_Definition (P);
+            R_Copy : constant Node_Id    := New_Copy_Tree (DS);
+            Loc    : constant Source_Ptr := Sloc (N);
+
+            function Rewrite_Bound
+              (Val : Node_Id; Typ : Entity_Id;
+               Rewrote_Bound : out Boolean)
+               return Node_Id;
+            --  Rewrites bound as reference to constant variable
+
+            procedure Relocate_Subtype_Bounds
+              (S : Node_Id; Typ : Entity_Id);
+            --  Moves discrete subtype definition bounds into variables
+            --  before the loop. This ensures that the bounds are not
+            --  reevaluated inside the loop.
+
+            -------------------
+            -- Rewrite_Bound --
+            -------------------
+
+            function Rewrite_Bound
+              (Val : Node_Id; Typ : Entity_Id;
+               Rewrote_Bound : out Boolean)
+               return Node_Id
+            is
+            begin
+               --  Skip over literal values
+
+               Rewrote_Bound := False;
+               if Nkind (Val) in
+                 N_Integer_Literal | N_Character_Literal
+               then
+                  return Val;
+               end if;
+
+               --  Create a new object declaration to
+               --  store the bound value
+
+               Rewrote_Bound := True;
+               declare
+                  New_Val : constant Entity_Id :=
+                    Make_Temporary (Loc, 'P');
+               begin
+                  --  New_Val : constant Subtype_Mark := Old_Val;
+
+                  Insert_Before_And_Analyze (N,
+                    Make_Object_Declaration (Loc,
+                      Defining_Identifier => New_Val,
+                      Expression          => Val,
+                      Constant_Present    => True,
+                      Object_Definition   =>
+                        New_Occurrence_Of (Typ, Loc)));
+
+                  Set_Is_Safe_To_Reevaluate (New_Val);
+                  return New_Occurrence_Of (New_Val, Loc);
+               end;
+            end Rewrite_Bound;
+
+            -----------------------------
+            -- Relocate_Subtype_Bounds --
+            -----------------------------
+
+            procedure Relocate_Subtype_Bounds
+              (S : Node_Id; Typ : Entity_Id)
+            is
+               C  : constant Node_Id :=
+                 Range_Expression (Constraint (S));
+               SM : constant Entity_Id :=
+                 Etype (Subtype_Mark (S));
+
+               Old_Low : constant Node_Id := Low_Bound (C);
+               Old_Hi  : constant Node_Id := High_Bound (C);
+
+               Rewrote_Hi  : Boolean := False;
+               Rewrote_Low : Boolean := False;
+
+               New_Low : constant Node_Id :=
+                 Rewrite_Bound (Old_Low, SM, Rewrote_Low);
+               New_Hi  : constant Node_Id :=
+                 Rewrite_Bound (Old_Hi, SM, Rewrote_Hi);
+            begin
+               --  Rewrite subtype indication if either bound was
+               --  changed
+               if Rewrote_Hi or else Rewrote_Low then
+                  Rewrite (S, Make_Subtype_Indication (Loc,
+                    Subtype_Mark       => Subtype_Mark (S),
+                    Constraint         => Make_Range_Constraint (Loc,
+                      Range_Expression => Make_Range (Loc,
+                        Low_Bound      => New_Low,
+                        High_Bound     => New_Hi))));
+                  Analyze (S);
+               end if;
+            end Relocate_Subtype_Bounds;
+
+         begin
+            Hi := Empty;
+            Lo := Empty;
+
+            --  Check if the loop param is of a discrete type
+
+            Set_Parent (R_Copy, Parent (DS));
+            Preanalyze_Range (R_Copy);
+            Typ := Etype (R_Copy);
+
+            if not Is_Discrete_Type (Etype (R_Copy)) then
+               Wrong_Type (R_Copy, Any_Discrete);
+            end if;
+
+            --  Analyze the discrete range and move function calls
+            --  inside the range before the parallel loop
+
+            if Nkind (DS) = N_Range
+              and then Expander_Active
+            then
+               Process_Bounds (DS, N, Sloc (P));
+
+            else
+               Analyze (DS);
+
+               if Nkind (DS) = N_Subtype_Indication
+                 and then Present (Constraint (DS))
+                 and then Nkind (Constraint (DS)) = N_Range_Constraint
+               then
+                  Relocate_Subtype_Bounds (DS, Typ);
+               end if;
+            end if;
+
+            --  Process 'Range attributes
+
+            if Nkind (DS) = N_Attribute_Reference
+              and then Attribute_Name (DS) = Name_Range
+            then
+               --  Ensure that the prefix expression on an attribute
+               --  reference is evaluated once outside of the parallel
+               --  loop. If the prefix is anything but an identifier,
+               --  we move the expression into a seperate declaration.
+
+               if Nkind (Prefix (DS)) /= N_Identifier
+                 and then not (Is_Entity_Name (Prefix (DS))
+                   and then Is_Type (Entity (Prefix (DS))))
+                 and then Expander_Active
+               then
+                  declare
+                     Func_Temp : constant Entity_Id :=
+                       Make_Temporary (Loc, 'P');
+                  begin
+                     Insert_Before_And_Analyze (N,
+                       Make_Object_Declaration (Loc,
+                         Defining_Identifier => Func_Temp,
+                         Expression          => Relocate_Node (Prefix (DS)),
+                         Object_Definition   =>
+                           New_Occurrence_Of (Etype (Prefix (DS)), Loc)));
+                     Rewrite (DS,
+                       Make_Attribute_Reference (Loc,
+                         Prefix         => New_Occurrence_Of (Func_Temp, Loc),
+                         Attribute_Name => Name_Range));
+                  end;
+               end if;
+
+               --  Resolve the range so that we can extract the
+               --  upper and lower bounds.
+
+               Analyze_And_Resolve (DS);
+            end if;
+
+            --  Read out high and low bounds for each kind of loop
+            --  parameter discrete subtype definition.
+
+            if Nkind (DS) = N_Subtype_Indication
+              and then Present (Constraint (DS))
+              and then Nkind (Constraint (DS)) = N_Range_Constraint
+            then
+               Lo := Low_Bound (Range_Expression (Constraint (DS)));
+               Hi := High_Bound (Range_Expression (Constraint (DS)));
+
+            elsif Nkind (DS) = N_Range then
+               Lo := Low_Bound (DS);
+               Hi := High_Bound (DS);
+
+            elsif Is_Entity_Name (DS)
+              and then Is_Type (Entity (DS))
+            then
+               declare
+                  Typ : constant Entity_Id := Get_Full_View (Entity (DS));
+               begin
+                  Lo := Type_Low_Bound  (Typ);
+                  Hi := Type_High_Bound (Typ);
+               end;
+
+            else
+               Error_Msg_N ("invalid subtype mark in discrete range", DS);
+            end if;
+         end Prepare_Parallel_Loop_Param;
+
+         ---------------------------
+         -- Create_Par_Range_Loop --
+         ---------------------------
+
+         procedure Create_Par_Range_Loop
+           (Low_Val : Node_Id; Hi_Val : Node_Id)
+         is
             Loc        : constant Source_Ptr := Sloc (N);
             Chunk_Spec : constant Node_Id    := Chunk_Specification (Iter);
             Loop_Id    : constant Entity_Id  := Entity (Identifier (N));
 
-            Outlined_Body, Outlined_Spec, Chunk_Arg, Parallel_Call : Node_Id;
+            Outlined_Spec, Chunk_Arg : Node_Id;
             Decls : constant List_Id := New_List;
 
             Spec_Id      : constant Entity_Id := Make_Temporary (Loc, 'P');
@@ -3662,40 +3887,8 @@ package body Sem_Ch5 is
             Chunk_Param  : constant Entity_Id := Make_Temporary (Loc, 'P');
             Long_Int_Typ : constant Entity_Id := RTE (RE_Longest_Integer);
 
-            procedure Read_Bounds
-              (DS : Node_Id; Lo : out Node_Id; Hi : out Node_Id);
-            --  Reads range or subtype indication's lower and upper bounds
-
             function Create_Bound_Arg (Arg : Node_Id) return Node_Id;
             --  Creates a lower or upper bound argument for the LWT call
-
-            procedure Prepare_Loop_Param
-              (P : Node_Id; Lo : out Node_Id;
-               Hi : out Node_Id; Typ : out Entity_Id);
-            --  Prepares loop parameter P by moving any calls into the
-            --  enclosing block. Low and high values are written to Lo
-            --  and Hi respectively, and Typ is set to the loop parameter
-            --  type.
-
-            -----------------
-            -- Read_Bounds --
-            -----------------
-
-            procedure Read_Bounds
-              (DS : Node_Id; Lo : out Node_Id; Hi : out Node_Id)
-            is
-            begin
-               if Nkind (DS) = N_Subtype_Indication
-                  and then Present (Constraint (DS))
-                  and then Nkind (Constraint (DS)) = N_Range_Constraint
-               then
-                  Lo := Low_Bound (Range_Expression (Constraint (DS)));
-                  Hi := High_Bound (Range_Expression (Constraint (DS)));
-               else
-                  Lo := Low_Bound (DS);
-                  Hi := High_Bound (DS);
-               end if;
-            end Read_Bounds;
 
             ----------------------
             -- Create_Bound_Arg --
@@ -3708,122 +3901,19 @@ package body Sem_Ch5 is
             begin
                --  Creates the expression
                --    Longest_Integer'Value (Range_Typ'Pos (Arg))
+
                To_Pos := Make_Attribute_Reference (Loc,
                  Prefix => New_Occurrence_Of (Etype (Arg), Loc),
                  Attribute_Name => Name_Pos,
                  Expressions => New_List (Copy_Separate_Tree (Arg)));
+
                To_Long_Int := Make_Attribute_Reference (Loc,
                  Prefix => New_Occurrence_Of (Long_Int_Typ, Loc),
                  Attribute_Name => Name_Val,
                  Expressions => New_List (To_Pos));
+
                return To_Long_Int;
             end Create_Bound_Arg;
-
-            ------------------------
-            -- Prepare_Loop_Param --
-            ------------------------
-
-            procedure Prepare_Loop_Param
-              (P : Node_Id; Lo : out Node_Id;
-               Hi : out Node_Id; Typ : out Entity_Id)
-            is
-               DS     : constant Node_Id := Discrete_Subtype_Definition (P);
-               R_Copy : constant Node_Id := New_Copy_Tree (DS);
-            begin
-               Hi := Empty;
-               Lo := Empty;
-
-               --  Check if the loop param is of a discrete type
-
-               Set_Parent (R_Copy, Parent (DS));
-               Preanalyze_Range (R_Copy);
-               Typ := Etype (R_Copy);
-
-               if not Is_Discrete_Type (Etype (R_Copy)) then
-                  Wrong_Type (R_Copy, Any_Discrete);
-               end if;
-
-               --  Analyze the discrete range and move function calls
-               --  inside the range before the parallel loop
-
-               if Nkind (DS) = N_Range
-                 and then Expander_Active
-               then
-                  Process_Bounds (DS, N, Sloc (P));
-
-               else
-                  Analyze (DS);
-               end if;
-
-               Check_Static_Loop_Bounds (P, DS, N);
-
-               --  Process 'Range attributes
-
-               if Nkind (DS) = N_Attribute_Reference
-                 and then Attribute_Name (DS) = Name_Range
-               then
-                  --  Ensure that the prefix expression on an attribute
-                  --  reference is evaluated once outside of the parallel
-                  --  loop. If the prefix is anything but an identifier,
-                  --  we move the expression into a seperate declaration.
-
-                  if Nkind (Prefix (DS)) /= N_Identifier
-                    and then not (Is_Entity_Name (Prefix (DS))
-                      and then Is_Type (Entity (Prefix (DS))))
-                    and then Expander_Active
-                  then
-                     declare
-                        Func_Temp : constant Entity_Id :=
-                          Make_Temporary (Loc, 'P');
-                        Decl : Node_Id;
-                     begin
-                        Decl := Make_Object_Declaration (Loc,
-                          Defining_Identifier => Func_Temp,
-                          Expression          => Relocate_Node (Prefix (DS)),
-                          Object_Definition   =>
-                            New_Occurrence_Of (Etype (Prefix (DS)), Loc));
-                        Insert_Before_And_Analyze (N, Decl);
-
-                        Rewrite (DS,
-                          Make_Attribute_Reference (Loc,
-                            Prefix         => New_Occurrence_Of (
-                                                Func_Temp, Loc),
-                            Attribute_Name => Name_Range));
-                        Analyze_And_Resolve (DS);
-                     end;
-
-                  --  Otherwise, resolve the range so that we can extract the
-                  --  upper and lower bounds.
-
-                  else
-                     Analyze_And_Resolve (DS);
-                  end if;
-               end if;
-
-               if Nkind (DS) in N_Subtype_Indication | N_Range then
-                  Read_Bounds (DS, Lo, Hi);
-
-               elsif Is_Entity_Name (DS)
-                 and then Is_Type (Entity (DS))
-               then
-                  declare
-                     Typ : constant Entity_Id := Get_Full_View (
-                       Entity (DS));
-                  begin
-                     if not Is_Discrete_Type (Typ) then
-                        Error_Msg_N ("discrete type required for " &
-                          (if Nkind (P) = N_Loop_Parameter_Specification then
-                            "loop parameter" else "chunk specification"), N);
-                     end if;
-
-                     Lo := Type_Low_Bound  (Typ);
-                     Hi := Type_High_Bound (Typ);
-                  end;
-
-               else
-                  Error_Msg_N ("invalid subtype mark in discrete range", DS);
-               end if;
-            end Prepare_Loop_Param;
 
          begin
             --  Relocates the parallel loop inside an outlined procedure and
@@ -3901,7 +3991,7 @@ package body Sem_Ch5 is
                   --  Move chunk specification values with side effects
                   --  outside of loop before we wrap it in a procedure
 
-                  Prepare_Loop_Param (Chunk_Spec, Low, Hi, Typ);
+                  Prepare_Parallel_Loop_Param (Chunk_Spec, Low, Hi, Typ);
 
                   --  Chunk_Type'Pos (Hi) - Chunk_Type'Pos (Lo)
 
@@ -3950,99 +4040,26 @@ package body Sem_Ch5 is
               Hi_Param    => Hi_Param,
               Chunk_Param => Chunk_Param);
             Set_Parallel_Chunk_Id (N, Chunk_Param);
+            Set_Parallel_Low_Bound (N, Low_Param);
+            Set_Parallel_Hi_Bound (N, Hi_Param);
 
-            declare
-               DS : constant Node_Id :=
-                 Discrete_Subtype_Definition (Param_Spec);
-               Low, Hi, New_DS, Low_Bound, Hi_Bound : Node_Id;
-               Typ : Entity_Id;
+            --  Move the loop inside the outlined procedure
 
-               --  Casts parameter value of LWT.Longest_Integer
-               --  type to the original loop's loop parameter type
-               --  with range checks.
-               function Cast_Loop_Bound
-                 (Param : Entity_Id; T : Entity_Id)
-                  return Node_Id;
+            Insert_Before_And_Analyze (N, Make_Subprogram_Body (Loc,
+              Specification              => Outlined_Spec,
+              Declarations               => Decls,
+              Handled_Statement_Sequence =>
+                Make_Handled_Sequence_Of_Statements (Loc,
+                  Statements             => New_List
+                    (Relocate_Node (N)))));
 
-               ---------------------
-               -- Cast_Loop_Bound --
-               ---------------------
+            --  Build call to Par_Range_Loop_With_Early_Exit
 
-               function Cast_Loop_Bound
-                 (Param : Entity_Id; T : Entity_Id)
-                  return Node_Id
-               is
-                  Cast_Ident : constant Entity_Id :=
-                    Make_Temporary (Loc, 'P');
-                  Cast : constant Node_Id :=
-                    Make_Attribute_Reference (Loc,
-                      Prefix => New_Occurrence_Of (T, Loc),
-                      Attribute_Name => Name_Val,
-                      Expressions => New_List
-                        (New_Occurrence_Of (Param, Loc)));
-                  Cast_Decl : constant Node_Id :=
-                    Make_Object_Declaration (Loc,
-                      Defining_Identifier => Cast_Ident,
-                      Object_Definition   => New_Occurrence_Of (T, Loc),
-                      Expression          => Cast,
-                      Constant_Present    => True);
-               begin
-                  Append (Cast_Decl, Decls);
-                  return New_Occurrence_Of (Cast_Ident, Loc);
-               end Cast_Loop_Bound;
-            begin
-               --  Move loop parameter values with side effects
-               --  outside of loop before we wrap it in a procedure
-
-               Prepare_Loop_Param (Param_Spec, Low, Hi, Typ);
-
-               --  Move the loop inside the outlined procedure
-
-               Outlined_Body := Make_Subprogram_Body (Loc,
-                 Specification => Outlined_Spec,
-                 Declarations => Decls,
-                 Handled_Statement_Sequence =>
-                   Make_Handled_Sequence_Of_Statements (Loc,
-                     Statements => New_List (Relocate_Node (N))));
-
-               --  Build call to Par_Range_Loop_With_Early_Exit
-
-               Parallel_Call := Build_Parallel_Call (Loc,
-                 Low_Arg => Create_Bound_Arg (Low),
-                 Hi_Arg => Create_Bound_Arg (Hi),
-                 Chunk_Arg => Chunk_Arg,
-                 Outlined_Proc => New_Occurrence_Of (Spec_Id, Loc));
-
-               --  Cast loop bounds from Longest_Integer to their type
-               --  in the original loop.
-
-               if Nkind (DS) = N_Subtype_Indication
-                 and then Present (Constraint (DS))
-                 and then Nkind (Constraint (DS)) = N_Range_Constraint
-               then
-                  declare
-                     SM : constant Entity_Id :=
-                       Entity (Subtype_Mark (DS));
-                  begin
-                     Low_Bound := Cast_Loop_Bound (Low_Param, SM);
-                     Hi_Bound := Cast_Loop_Bound (Hi_Param, SM);
-                  end;
-               else
-                  Low_Bound := Cast_Loop_Bound (Low_Param, Typ);
-                  Hi_Bound := Cast_Loop_Bound (Hi_Param, Typ);
-               end if;
-
-               --  Rewrite loop range as Low_Param .. High_Param
-
-               New_DS := Make_Range (Loc,
-                 Low_Bound => Low_Bound,
-                 High_Bound => Hi_Bound);
-               Set_Discrete_Subtype_Definition (Param_Spec, New_DS);
-            end;
-
-            Insert_Before_And_Analyze (N, Outlined_Body);
-
-            Rewrite (N, Parallel_Call);
+            Rewrite (N, Build_Parallel_Call (Loc,
+              Low_Arg       => Create_Bound_Arg (Low_Val),
+              Hi_Arg        => Create_Bound_Arg (Hi_Val),
+              Chunk_Arg     => Chunk_Arg,
+              Outlined_Proc => New_Occurrence_Of (Spec_Id, Loc)));
             Analyze (N);
 
             --  Check our parallel scope for a saved exit actions
@@ -4059,7 +4076,7 @@ package body Sem_Ch5 is
 
             Remove_Entity (Loop_Id);
             Append_Entity (Loop_Id, Spec_Id);
-         end Outline_Loop;
+         end Create_Par_Range_Loop;
 
          ----------------------------
          -- Prepare_Parallel_Chunk --
@@ -4100,16 +4117,27 @@ package body Sem_Ch5 is
          begin
             Stop_Processing := False;
 
-            if Present (Iter_Spec) then
-               Error_Msg_N ("Parallel iteration over " &
-                 "containers not yet supported", N);
-
-            elsif In_Outlined_Parallel (N) then
+            if In_Outlined_Parallel (N) then
                null;
 
             elsif Lwt_Availible then
-               Outline_Loop;
-               Stop_Processing := True;
+               --  TODO: Iteration over containers
+
+               if Present (Iter_Spec) then
+                  Error_Msg_N ("Parallel iteration over " &
+                    "containers not yet supported", N);
+
+               else
+                  declare
+                     Low, Hi : Node_Id;
+                     Typ : Entity_Id;
+                  begin
+                     Prepare_Parallel_Loop_Param
+                       (Param_Spec, Low, Hi, Typ);
+                     Create_Par_Range_Loop (Low, Hi);
+                  end;
+                  Stop_Processing := True;
+               end if;
 
             else
                Error_Msg_N ("LWT library not found. Parallel loop " &

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -4224,6 +4224,10 @@ package body Sem_Ch5 is
             begin
                Preanalyze_Range (Iter_Name);
 
+               --  Move the loop's iter name outside of the loop to
+               --  prevent any side effects from occurring inside
+               --  the outlined procedure.
+
                if not Is_Entity_Name (Iter_Name)
                  and then Full_Analysis
                  and then (Expander_Active or GNATprove_Mode)

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -4228,10 +4228,7 @@ package body Sem_Ch5 is
                --  prevent any side effects from occurring inside
                --  the outlined procedure.
 
-               if not Is_Entity_Name (Iter_Name)
-                 and then Full_Analysis
-                 and then (Expander_Active or GNATprove_Mode)
-               then
+               if not Is_Entity_Name (Iter_Name) then
                   Move_Iter_Name (Iter_Name);
                end if;
 

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -158,6 +158,17 @@ package body Sem_Ch5 is
    --  the value of Chunk_Arg (the CHUNK_COUNT value that is passed
    --  to LWT)
 
+   procedure Move_Iter_Name (Iter_Name : Node_Id);
+   --  Moves an expression inside an iteration specification name
+   --  into a separate declaration. This expression is rewritten as a
+   --  renaming declaration.
+
+   procedure Check_Reverse_Iteration
+     (I_Spec : Node_Id; Typ : Entity_Id);
+   --  For an iteration over a container, if the loop carries the Reverse
+   --  indicator, verify that the container type has an Iterate aspect that
+   --  implements the reversible iterator interface.
+
    ------------------------
    -- Analyze_Assignment --
    ------------------------
@@ -2229,11 +2240,6 @@ package body Sem_Ch5 is
       Iter_Func : Node_Id;
       Typ : Entity_Id;
 
-      procedure Check_Reverse_Iteration (Typ : Entity_Id);
-      --  For an iteration over a container, if the loop carries the Reverse
-      --  indicator, verify that the container type has an Iterate aspect that
-      --  implements the reversible iterator interface.
-
       procedure Check_Subtype_Definition (Comp_Type : Entity_Id);
       --  If a subtype indication is present, verify that it is consistent
       --  with the component type of the array or container name.
@@ -2244,29 +2250,6 @@ package body Sem_Ch5 is
       --  For containers with Iterator and related aspects, the cursor is
       --  obtained by locating an entity with the proper name in the scope
       --  of the type.
-
-      -----------------------------
-      -- Check_Reverse_Iteration --
-      -----------------------------
-
-      procedure Check_Reverse_Iteration (Typ : Entity_Id) is
-      begin
-         if Reverse_Present (N) then
-            if Is_Array_Type (Typ)
-              or else Is_Reversible_Iterator (Typ)
-              or else
-                (Has_Aspect (Typ, Aspect_Iterable)
-                  and then
-                    Present
-                      (Get_Iterable_Type_Primitive (Typ, Name_Previous)))
-            then
-               null;
-            else
-               Error_Msg_N
-                 ("container type does not support reverse iteration", N);
-            end if;
-         end if;
-      end Check_Reverse_Iteration;
 
       -------------------------------
       --  Check_Subtype_Definition --
@@ -2478,7 +2461,7 @@ package body Sem_Ch5 is
                   end if;
 
                elsif not Is_Overloaded (Iterator) then
-                  Check_Reverse_Iteration (Etype (Iterator));
+                  Check_Reverse_Iteration (N, Etype (Iterator));
 
                --  If Iterator is overloaded, use reversible iterator if one is
                --  available.
@@ -2497,7 +2480,7 @@ package body Sem_Ch5 is
                      Get_Next_Interp (I, It);
                   end loop;
 
-                  Check_Reverse_Iteration (Etype (Iterator));
+                  Check_Reverse_Iteration (N, Etype (Iterator));
                end if;
             end;
          end if;
@@ -2521,97 +2504,7 @@ package body Sem_Ch5 is
 
         and then (Expander_Active or GNATprove_Mode)
       then
-         declare
-            Id    : constant Entity_Id := Make_Temporary (Loc, 'R', Iter_Name);
-            Decl  : Node_Id;
-            Act_S : Node_Id;
-
-         begin
-
-            --  If the domain of iteration is an array component that depends
-            --  on a discriminant, create actual subtype for it. Preanalysis
-            --  does not generate the actual subtype of a selected component.
-
-            if Nkind (Iter_Name) = N_Selected_Component
-              and then Is_Array_Type (Etype (Iter_Name))
-            then
-               Act_S :=
-                 Build_Actual_Subtype_Of_Component
-                   (Etype (Selector_Name (Iter_Name)), Iter_Name);
-               Insert_Action (N, Act_S);
-
-               if Present (Act_S) then
-                  Typ := Defining_Identifier (Act_S);
-               else
-                  Typ := Etype (Iter_Name);
-               end if;
-
-            else
-               Typ := Etype (Iter_Name);
-
-               --  Verify that the expression produces an iterator
-
-               if not Of_Present (N) and then not Is_Iterator (Typ)
-                 and then not Is_Array_Type (Typ)
-                 and then No (Find_Aspect (Typ, Aspect_Iterable))
-               then
-                  Error_Msg_N
-                    ("expect object that implements iterator interface",
-                     Iter_Name);
-               end if;
-            end if;
-
-            --  Protect against malformed iterator
-
-            if Typ = Any_Type then
-               Error_Msg_N ("invalid expression in loop iterator", Iter_Name);
-               return;
-            end if;
-
-            if not Of_Present (N) then
-               Check_Reverse_Iteration (Typ);
-            end if;
-
-            --  For an element iteration over a slice, we must complete
-            --  the resolution and expansion of the slice bounds. These
-            --  can be arbitrary expressions, and the preanalysis that
-            --  was performed in preparation for the iteration may have
-            --  generated an itype whose bounds must be fully expanded.
-            --  We set the parent node to provide a proper insertion
-            --  point for generated actions, if any.
-
-            if Nkind (Iter_Name) = N_Slice
-              and then Nkind (Discrete_Range (Iter_Name)) = N_Range
-              and then not Analyzed (Discrete_Range (Iter_Name))
-            then
-               declare
-                  Indx : constant Node_Id :=
-                     Entity (First_Index (Etype (Iter_Name)));
-               begin
-                  Set_Parent (Indx, Iter_Name);
-                  Resolve (Scalar_Range (Indx), Etype (Indx));
-               end;
-            end if;
-
-            --  The name in the renaming declaration may be a function call.
-            --  Indicate that it does not come from source, to suppress
-            --  spurious warnings on renamings of parameterless functions,
-            --  a common enough idiom in user-defined iterators.
-
-            Decl :=
-              Make_Object_Renaming_Declaration (Loc,
-                Defining_Identifier => Id,
-                Subtype_Mark        => New_Occurrence_Of (Typ, Loc),
-                Name                =>
-                  New_Copy_Tree (Iter_Name, New_Sloc => Loc));
-            Set_Comes_From_Iterator (Decl);
-
-            Insert_Actions (Parent (Parent (N)), New_List (Decl));
-            Rewrite (Name (N), New_Occurrence_Of (Id, Loc));
-            Analyze (Name (N));
-            Set_Etype (Id, Typ);
-            Set_Etype (Name (N), Typ);
-         end;
+         Move_Iter_Name (Iter_Name);
 
       --  Container is an entity or an array with uncontrolled components, or
       --  else it is a container iterator given by a function call, typically
@@ -2658,7 +2551,7 @@ package body Sem_Ch5 is
          end if;
 
          if not Of_Present (N) then
-            Check_Reverse_Iteration (Etype (Iter_Name));
+            Check_Reverse_Iteration (N, Etype (Iter_Name));
          end if;
       end if;
 
@@ -2748,7 +2641,7 @@ package body Sem_Ch5 is
                        ("missing Element primitive for iteration", N);
                   else
                      Set_Etype (Def_Id, Etype (Elt));
-                     Check_Reverse_Iteration (Typ);
+                     Check_Reverse_Iteration (N, Typ);
                   end if;
                end;
 
@@ -2941,7 +2834,7 @@ package body Sem_Ch5 is
                Set_Etype (Def_Id, Get_Cursor_Type (Iter_Asp, Typ));
             else
                Set_Etype (Def_Id, Get_Cursor_Type (Typ));
-               Check_Reverse_Iteration (Etype (Iter_Name));
+               Check_Reverse_Iteration (N, Etype (Iter_Name));
             end if;
 
          end if;
@@ -3638,7 +3531,7 @@ package body Sem_Ch5 is
               (Val : Node_Id; Typ : Entity_Id;
                Rewrote_Bound : out Boolean)
                return Node_Id;
-            --  Rewrites bound as reference to constant variable
+            --  Rewrites bound as reference to constant declaration
 
             procedure Relocate_Subtype_Bounds
               (S : Node_Id; Typ : Entity_Id);
@@ -3807,6 +3700,8 @@ package body Sem_Ch5 is
          procedure Create_Par_Range_Loop
            (Low_Val : Node_Id; Hi_Val : Node_Id)
          is
+            pragma Assert (Lwt_Availible);
+
             Loc        : constant Source_Ptr := Sloc (N);
             Chunk_Spec : constant Node_Id    := Chunk_Specification (Iter);
             Loop_Id    : constant Entity_Id  := Entity (Identifier (N));
@@ -3830,22 +3725,10 @@ package body Sem_Ch5 is
             function Create_Bound_Arg (Arg : Node_Id)
               return Node_Id
             is
-               To_Pos, To_Long_Int : Node_Id;
             begin
-               --  Creates the expression
-               --    Longest_Integer'Value (Range_Typ'Pos (Arg))
-
-               To_Pos := Make_Attribute_Reference (Loc,
-                 Prefix => New_Occurrence_Of (Etype (Arg), Loc),
-                 Attribute_Name => Name_Pos,
-                 Expressions => New_List (Copy_Separate_Tree (Arg)));
-
-               To_Long_Int := Make_Attribute_Reference (Loc,
-                 Prefix => New_Occurrence_Of (Long_Int_Typ, Loc),
-                 Attribute_Name => Name_Val,
-                 Expressions => New_List (To_Pos));
-
-               return To_Long_Int;
+               return Make_Type_Conversion (Loc,
+                 Subtype_Mark => New_Occurrence_Of (Long_Int_Typ, Loc),
+                 Expression   => New_Copy_Tree (Arg));
             end Create_Bound_Arg;
 
          begin
@@ -3989,10 +3872,14 @@ package body Sem_Ch5 is
             --  Build call to Par_Range_Loop_With_Early_Exit
 
             Rewrite (N, Build_Parallel_Call (Loc,
-              Low_Arg       => Create_Bound_Arg (Low_Val),
-              Hi_Arg        => Create_Bound_Arg (Hi_Val),
-              Chunk_Arg     => Chunk_Arg,
-              Outlined_Proc => New_Occurrence_Of (Spec_Id, Loc)));
+              Low_Arg        => Make_Type_Conversion (Loc,
+                Subtype_Mark => New_Occurrence_Of (Long_Int_Typ, Loc),
+                Expression   => New_Copy_Tree (Low_Val)),
+              Hi_Arg         => Make_Type_Conversion (Loc,
+                Subtype_Mark => New_Occurrence_Of (Long_Int_Typ, Loc),
+                Expression   => New_Copy_Tree (Hi_Val)),
+              Chunk_Arg      => Chunk_Arg,
+              Outlined_Proc  => New_Occurrence_Of (Spec_Id, Loc)));
             Analyze (N);
 
             --  Check our parallel scope for a saved exit actions
@@ -4047,31 +3934,134 @@ package body Sem_Ch5 is
          ---------------------------
 
          procedure Prepare_Outlined_Loop (Stop_Processing : out Boolean) is
+
+            function Get_Array_Size (Array_Node : Node_Id) return Node_Id;
+            --  Gets the overall size of a multidimensional array
+
+            procedure Prepare_Iter_Spec (I_Spec : Node_Id);
+            --  Prepare for ... of loop
+
+            procedure Prepare_Loop_Param (LPS : Node_Id);
+            --  Prepare for ... in loop
+
+            --------------------
+            -- Get_Array_Size --
+            --------------------
+
+            function Get_Array_Size (Array_Node : Node_Id) return Node_Id is
+               Loc       : constant Source_Ptr := Sloc (N);
+               Array_Typ : constant Entity_Id  := Base_Type (Etype (Array_Node));
+
+               function Get_Dim (I : Pos) return Node_Id;
+               --  Gets array length for dimension I
+
+               -------------
+               -- Get_Dim --
+               -------------
+
+               function Get_Dim (I : Pos) return Node_Id is
+               begin
+                  return Make_Attribute_Reference (Loc,
+                    Prefix         => New_Copy_Tree (Array_Node),
+                    Attribute_Name => Name_Length,
+                    Expressions    => New_List
+                      (Make_Integer_Literal (Loc, I)));
+               end Get_Dim;
+
+               Array_Dim : constant Pos := Number_Dimensions (Array_Typ);
+               Product   : Node_Id      := Get_Dim (1);
+               Total_Len : Node_Id;
+            begin
+               --  Multiply the lengths of each array dimension length together
+
+               --     Arr_Typ'Length (1) * Arr_Typ'Length (2) *
+               --       ... * Arr_Typ'Length (I)
+
+               for Dim in 2 .. Array_Dim loop
+                  Product := Make_Op_Multiply (Loc,
+                    Left_Opnd  => Product,
+                    Right_Opnd => Get_Dim (Dim));
+               end loop;
+
+               --  Subtract one from the product
+
+               Total_Len := Make_Op_Subtract (Loc,
+                 Left_Opnd => Product,
+                 Right_Opnd => Make_Integer_Literal (Loc, Uint_1));
+
+               Analyze (Total_Len);
+               return Total_Len;
+            end Get_Array_Size;
+
+            -----------------------
+            -- Prepare_Iter_Spec --
+            -----------------------
+
+            procedure Prepare_Iter_Spec (I_Spec : Node_Id) is
+               Iter_Name : constant Node_Id := Name (I_Spec);
+               Loc       : constant Source_Ptr := Sloc (N);
+
+            begin
+               Preanalyze_Range (Iter_Name);
+
+               if not Is_Entity_Name (Iter_Name)
+                 and then Full_Analysis
+                 and then (Expander_Active or GNATprove_Mode)
+               then
+                  Move_Iter_Name (Iter_Name);
+               end if;
+
+               --  Outline and make LWT call for iteration over
+               --  arrays
+
+               if Is_Array_Type (Etype (Iter_Name)) then
+                  declare
+                     Lower_Bound : constant Node_Id :=
+                       Make_Integer_Literal (Loc, Uint_0);
+                     Upper_Bound : constant Node_Id :=
+                       Get_Array_Size (Iter_Name);
+                  begin
+                     Create_Par_Range_Loop (Lower_Bound, Upper_Bound);
+                  end;
+
+               --  TODO: parallel iterators
+
+               else
+                  Error_Msg_N ("Parallel iteration over " &
+                    "containers not yet supported", N);
+               end if;
+            end Prepare_Iter_Spec;
+
+            ------------------------
+            -- Prepare_Loop_Param --
+            ------------------------
+
+            procedure Prepare_Loop_Param (LPS : Node_Id) is
+               Low, Hi : Node_Id;
+               Typ     : Entity_Id;
+            begin
+               Prepare_Parallel_Loop_Param (LPS, Low, Hi, Typ);
+               Create_Par_Range_Loop (Low, Hi);
+            end Prepare_Loop_Param;
+
          begin
             Stop_Processing := False;
 
             if In_Outlined_Parallel (N) then
                null;
 
-            elsif Lwt_Availible then
-               --  TODO: Iteration over containers
+            --  Outline loop if the loop hasn't been outlined yet
+            --  and LWT is availible
 
+            elsif Lwt_Availible then
                if Present (Iter_Spec) then
-                  Error_Msg_N ("Parallel iteration over " &
-                    "containers not yet supported", N);
+                  Prepare_Iter_Spec (Iter_Spec);
 
                else
-                  declare
-                     Low, Hi : Node_Id;
-                     Typ : Entity_Id;
-                  begin
-                     Prepare_Parallel_Loop_Param
-                       (Param_Spec, Low, Hi, Typ);
-                     Create_Par_Range_Loop (Low, Hi);
-                  end;
-                  Stop_Processing := True;
+                  Prepare_Loop_Param (Param_Spec);
                end if;
 
+               Stop_Processing := True;
             else
                Error_Msg_N ("LWT library not found. Parallel loop " &
                  "will execute sequentially??", N);
@@ -4626,6 +4616,7 @@ package body Sem_Ch5 is
       Long_Int_Typ  : constant Entity_Id := RTE (RE_Longest_Integer);
       Loop_Id_Typ   : constant Entity_Id := RTE (RE_Par_Loop_Id);
       Loop_Id_Param : constant Entity_Id := Make_Temporary (Loc, 'P');
+
    begin
       --  Builds out the following procedure specification:
       --     procedure Proc_Name (Low : Longest_Integer;
@@ -5575,6 +5566,7 @@ package body Sem_Ch5 is
    is
       L, H : Node_Id;
       Null_Range : Boolean := False;
+
    begin
 
       if Nkind (DS) not in N_Range | N_Subtype_Indication
@@ -5793,6 +5785,7 @@ package body Sem_Ch5 is
      (DS : Node_Id; Loop_Nod : Node_Id)
    is
       Loc : constant Source_Ptr := Sloc (Loop_Nod);
+
    begin
       if Nkind (DS) = N_Attribute_Reference
         and then Is_Entity_Name (Prefix (DS))
@@ -5843,6 +5836,7 @@ package body Sem_Ch5 is
         or else Nkind (Chunk) = N_Chunk_Specification_Int);
       Loc        : constant Source_Ptr := Sloc (Chunk);
       Chunk_Temp : constant Entity_Id := Make_Temporary (Loc, 'P');
+
    begin
       Set_Etype (Chunk_Temp, Standard_Positive);
 
@@ -5863,5 +5857,132 @@ package body Sem_Ch5 is
          return Make_Integer_Literal (Loc, 0);
       end if;
    end Process_Chunk_Specification_Int;
+
+   --------------------
+   -- Move_Iter_Name --
+   --------------------
+
+   procedure Move_Iter_Name (Iter_Name : Node_Id) is
+      N     : constant Node_Id    := Parent (Iter_Name);
+      Loc   : constant Source_Ptr := Sloc (N);
+      Id    : constant Entity_Id  := Make_Temporary (Loc, 'R', Iter_Name);
+      Decl  : Node_Id;
+      Act_S : Node_Id;
+      Typ   : Entity_Id;
+
+   begin
+      if Is_Entity_Name (Iter_Name) then
+         return;
+      end if;
+
+      --  If the domain of iteration is an array component that depends
+      --  on a discriminant, create actual subtype for it. Preanalysis
+      --  does not generate the actual subtype of a selected component.
+
+      if Nkind (Iter_Name) = N_Selected_Component
+        and then Is_Array_Type (Etype (Iter_Name))
+      then
+         Act_S := Build_Actual_Subtype_Of_Component
+           (Etype (Selector_Name (Iter_Name)), Iter_Name);
+         Insert_Action (N, Act_S);
+
+         if Present (Act_S) then
+            Typ := Defining_Identifier (Act_S);
+         else
+            Typ := Etype (Iter_Name);
+         end if;
+
+      else
+         Typ := Etype (Iter_Name);
+
+         --  Verify that the expression produces an iterator
+
+         if not Of_Present (N) and then not Is_Iterator (Typ)
+           and then not Is_Array_Type (Typ)
+           and then No (Find_Aspect (Typ, Aspect_Iterable))
+         then
+            Error_Msg_N
+              ("expect object that implements iterator interface",
+               Iter_Name);
+         end if;
+      end if;
+
+      --  Protect against malformed iterator
+
+      if Typ = Any_Type then
+         Error_Msg_N ("invalid expression in loop iterator", Iter_Name);
+         return;
+      end if;
+
+      if not Of_Present (N) then
+         Check_Reverse_Iteration (N, Typ);
+      end if;
+
+      --  For an element iteration over a slice, we must complete
+      --  the resolution and expansion of the slice bounds. These
+      --  can be arbitrary expressions, and the preanalysis that
+      --  was performed in preparation for the iteration may have
+      --  generated an itype whose bounds must be fully expanded.
+      --  We set the parent node to provide a proper insertion
+      --  point for generated actions, if any.
+
+      if Nkind (Iter_Name) = N_Slice
+        and then Nkind (Discrete_Range (Iter_Name)) = N_Range
+        and then not Analyzed (Discrete_Range (Iter_Name))
+      then
+         declare
+            Indx : constant Node_Id :=
+              Entity (First_Index (Etype (Iter_Name)));
+         begin
+            Set_Parent (Indx, Iter_Name);
+            Resolve (Scalar_Range (Indx), Etype (Indx));
+         end;
+      end if;
+
+      --  The name in the renaming declaration may be a function call.
+      --  Indicate that it does not come from source, to suppress
+      --  spurious warnings on renamings of parameterless functions,
+      --  a common enough idiom in user-defined iterators.
+
+      Decl :=
+        Make_Object_Renaming_Declaration (Loc,
+          Defining_Identifier => Id,
+          Subtype_Mark        => New_Occurrence_Of (Typ, Loc),
+          Name                =>
+            New_Copy_Tree (Iter_Name, New_Sloc => Loc));
+      Set_Comes_From_Iterator (Decl);
+
+      Insert_Actions (Parent (Parent (N)), New_List (Decl));
+      Rewrite (Name (N), New_Occurrence_Of (Id, Loc));
+      Analyze (Name (N));
+      Set_Etype (Id, Typ);
+      Set_Etype (Name (N), Typ);
+   end Move_Iter_Name;
+
+   -----------------------------
+   -- Check_Reverse_Iteration --
+   -----------------------------
+
+   procedure Check_Reverse_Iteration
+     (I_Spec : Node_Id; Typ : Entity_Id)
+   is
+   begin
+      if Reverse_Present (I_Spec) then
+         if Is_Array_Type (Typ)
+           or else Is_Reversible_Iterator (Typ)
+           or else
+             (Has_Aspect (Typ, Aspect_Iterable)
+           and then
+             Present
+               (Get_Iterable_Type_Primitive (Typ, Name_Previous)))
+         then
+            null;
+         else
+            Error_Msg_N
+               ("container type does not support reverse iteration",
+                I_Spec);
+         end if;
+      end if;
+   end Check_Reverse_Iteration;
 
 end Sem_Ch5;

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -130,6 +130,13 @@ package body Sem_Ch5 is
    --  parameter N contains any bounds that can be proven invalid at compile
    --  time. Loop_Node is the loop statement parent of N.
 
+   procedure Check_Controlled_Array_Attribute
+     (DS : Node_Id; Loop_Nod : Node_Id);
+   --  If a loop parameter's bounds are given by a 'Range reference on a
+   --  function call that returns a controlled array, introduce an explicit
+   --  declaration to capture the bounds, so that the function result can be
+   --  finalized in timely fashion.
+
    function Build_Parallel_Loop_Spec
      (Loc : Source_Ptr; Spec_Id : Entity_Id;
       Low_Param : Entity_Id; Hi_Param : Entity_Id;
@@ -2991,61 +2998,11 @@ package body Sem_Ch5 is
    procedure Analyze_Loop_Parameter_Specification (N : Node_Id) is
       Loop_Nod : constant Node_Id := Parent (Parent (N));
 
-      procedure Check_Controlled_Array_Attribute (DS : Node_Id);
-      --  If the bounds are given by a 'Range reference on a function call
-      --  that returns a controlled array, introduce an explicit declaration
-      --  to capture the bounds, so that the function result can be finalized
-      --  in timely fashion.
-
       procedure Check_Predicate_Use (T : Entity_Id);
       --  Diagnose Attempt to iterate through non-static predicate. Note that
       --  a type with inherited predicates may have both static and dynamic
       --  forms. In this case it is not sufficient to check the static
       --  predicate function only, look for a dynamic predicate aspect as well.
-
-      --------------------------------------
-      -- Check_Controlled_Array_Attribute --
-      --------------------------------------
-
-      procedure Check_Controlled_Array_Attribute (DS : Node_Id) is
-      begin
-         if Nkind (DS) = N_Attribute_Reference
-           and then Is_Entity_Name (Prefix (DS))
-           and then Ekind (Entity (Prefix (DS))) = E_Function
-           and then Is_Array_Type (Etype (Entity (Prefix (DS))))
-           and then
-             Is_Controlled (Component_Type (Etype (Entity (Prefix (DS)))))
-           and then Expander_Active
-         then
-            declare
-               Loc  : constant Source_Ptr := Sloc (N);
-               Arr  : constant Entity_Id := Etype (Entity (Prefix (DS)));
-               Indx : constant Entity_Id :=
-                        Base_Type (Etype (First_Index (Arr)));
-               Subt : constant Entity_Id := Make_Temporary (Loc, 'S');
-               Decl : Node_Id;
-
-            begin
-               Decl :=
-                 Make_Subtype_Declaration (Loc,
-                   Defining_Identifier => Subt,
-                   Subtype_Indication  =>
-                      Make_Subtype_Indication (Loc,
-                        Subtype_Mark => New_Occurrence_Of (Indx, Loc),
-                        Constraint   =>
-                          Make_Range_Constraint (Loc, Relocate_Node (DS))));
-               Insert_Before (Loop_Nod, Decl);
-               Analyze (Decl);
-
-               Rewrite (DS,
-                 Make_Attribute_Reference (Loc,
-                   Prefix         => New_Occurrence_Of (Subt, Loc),
-                   Attribute_Name => Attribute_Name (DS)));
-
-               Analyze (DS);
-            end;
-         end if;
-      end Check_Controlled_Array_Attribute;
 
       -------------------------
       -- Check_Predicate_Use --
@@ -3250,7 +3207,7 @@ package body Sem_Ch5 is
          Set_Etype (DS, Any_Type);
       end if;
 
-      Check_Controlled_Array_Attribute (DS);
+      Check_Controlled_Array_Attribute (DS, Loop_Nod);
 
       if Nkind (DS) = N_Subtype_Indication then
          Check_Predicate_Use (Entity (Subtype_Mark (DS)));
@@ -3756,6 +3713,7 @@ package body Sem_Ch5 is
             begin
                --  Rewrite subtype indication if either bound was
                --  changed
+
                if Rewrote_Hi or else Rewrote_Low then
                   Rewrite (S, Make_Subtype_Indication (Loc,
                     Subtype_Mark       => Subtype_Mark (S),
@@ -3805,37 +3763,12 @@ package body Sem_Ch5 is
             if Nkind (DS) = N_Attribute_Reference
               and then Attribute_Name (DS) = Name_Range
             then
-               --  Ensure that the prefix expression on an attribute
-               --  reference is evaluated once outside of the parallel
-               --  loop. If the prefix is anything but an identifier,
-               --  we move the expression into a seperate declaration.
-
-               if Nkind (Prefix (DS)) /= N_Identifier
-                 and then not (Is_Entity_Name (Prefix (DS))
-                   and then Is_Type (Entity (Prefix (DS))))
-                 and then Expander_Active
-               then
-                  declare
-                     Func_Temp : constant Entity_Id :=
-                       Make_Temporary (Loc, 'P');
-                  begin
-                     Insert_Before_And_Analyze (N,
-                       Make_Object_Declaration (Loc,
-                         Defining_Identifier => Func_Temp,
-                         Expression          => Relocate_Node (Prefix (DS)),
-                         Object_Definition   =>
-                           New_Occurrence_Of (Etype (Prefix (DS)), Loc)));
-                     Rewrite (DS,
-                       Make_Attribute_Reference (Loc,
-                         Prefix         => New_Occurrence_Of (Func_Temp, Loc),
-                         Attribute_Name => Name_Range));
-                  end;
-               end if;
+               Check_Controlled_Array_Attribute (DS, N);
 
                --  Resolve the range so that we can extract the
                --  upper and lower bounds.
 
-               Analyze_And_Resolve (DS);
+               Resolve (DS);
             end if;
 
             --  Read out high and low bounds for each kind of loop
@@ -5851,6 +5784,53 @@ package body Sem_Ch5 is
          end;
       end if;
    end Check_Static_Loop_Bounds;
+
+   --------------------------------------
+   -- Check_Controlled_Array_Attribute --
+   --------------------------------------
+
+   procedure Check_Controlled_Array_Attribute
+     (DS : Node_Id; Loop_Nod : Node_Id)
+   is
+      Loc : constant Source_Ptr := Sloc (Loop_Nod);
+   begin
+      if Nkind (DS) = N_Attribute_Reference
+        and then Is_Entity_Name (Prefix (DS))
+        and then Ekind (Entity (Prefix (DS))) = E_Function
+        and then Is_Array_Type (Etype (Entity (Prefix (DS))))
+        and then
+          Is_Controlled (Component_Type (Etype (Entity (Prefix (DS)))))
+        and then Expander_Active
+      then
+         declare
+            Loc  : constant Source_Ptr := Sloc (Parent (DS));
+            Arr  : constant Entity_Id := Etype (Entity (Prefix (DS)));
+            Indx : constant Entity_Id :=
+                     Base_Type (Etype (First_Index (Arr)));
+            Subt : constant Entity_Id := Make_Temporary (Loc, 'S');
+            Decl : Node_Id;
+
+         begin
+            Decl :=
+              Make_Subtype_Declaration (Loc,
+                Defining_Identifier => Subt,
+                Subtype_Indication  =>
+                  Make_Subtype_Indication (Loc,
+                    Subtype_Mark => New_Occurrence_Of (Indx, Loc),
+                    Constraint   =>
+                      Make_Range_Constraint (Loc, Relocate_Node (DS))));
+            Insert_Before (Loop_Nod, Decl);
+            Analyze (Decl);
+
+            Rewrite (DS,
+              Make_Attribute_Reference (Loc,
+                Prefix         => New_Occurrence_Of (Subt, Loc),
+                Attribute_Name => Attribute_Name (DS)));
+
+            Analyze (DS);
+         end;
+      end if;
+   end Check_Controlled_Array_Attribute;
 
    -------------------------------------
    -- Process_Chunk_Specification_Int --

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -3388,7 +3388,7 @@ package body Sem_Ch5 is
          Iter_Spec  : constant Node_Id := Iterator_Specification (Iter);
          Param_Spec : constant Node_Id := Loop_Parameter_Specification (Iter);
 
-         Lwt_Availible : constant Boolean :=
+         Lwt_Available : constant Boolean :=
            Present (Iter) and then Is_Parallel (Iter)
            and then RTE_Available (RE_Par_Range_Loop_With_Early_Exit);
 
@@ -3919,7 +3919,7 @@ package body Sem_Ch5 is
          procedure Create_Par_Range_Loop
            (Low_Val : Node_Id; Hi_Val : Node_Id)
          is
-            pragma Assert (Lwt_Availible);
+            pragma Assert (Lwt_Available);
 
             Loc        : constant Source_Ptr := Sloc (N);
             Chunk_Spec : constant Node_Id    := Chunk_Specification (Iter);
@@ -4274,7 +4274,7 @@ package body Sem_Ch5 is
             --  Outline loop if the loop hasn't been outlined yet
             --  and LWT is availible
 
-            elsif Lwt_Availible then
+            elsif Lwt_Available then
                if Present (Iter_Spec) then
                   Prepare_Iter_Spec (Iter_Spec);
 
@@ -4320,7 +4320,7 @@ package body Sem_Ch5 is
 
             if Present (P_Decls)
               and then not Is_Empty_List (P_Decls)
-              and then not Lwt_Availible
+              and then not Lwt_Available
             then
                Blk_Dcl := P_Decls;
                Set_Parallel_Declarations (N, No_List);

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -3950,7 +3950,8 @@ package body Sem_Ch5 is
 
             function Get_Array_Size (Array_Node : Node_Id) return Node_Id is
                Loc       : constant Source_Ptr := Sloc (N);
-               Array_Typ : constant Entity_Id  := Base_Type (Etype (Array_Node));
+               Array_Typ : constant Entity_Id  := Base_Type
+                 (Etype (Array_Node));
 
                function Get_Dim (I : Pos) return Node_Id;
                --  Gets array length for dimension I
@@ -4118,11 +4119,14 @@ package body Sem_Ch5 is
             Rewrite (N, Blk);
             Analyze (N);
 
-            --  Transfer the loop entity from its old scope to the new block
-            --  scope.
+            --  Transfer the loop entity from its old scope to the new
+            --  block scope if it hasn't already been moved inside a
+            --  different procedure.
 
-            Remove_Entity (Loop_Id);
-            Append_Entity (Loop_Id, Blk_Id);
+            if not Is_Parallel_Loop_Scope (Loop_Id) then
+               Remove_Entity (Loop_Id);
+               Append_Entity (Loop_Id, Blk_Id);
+            end if;
          end Wrap_Loop_Statement;
       begin
          Stop_Processing := False;
@@ -4286,7 +4290,7 @@ package body Sem_Ch5 is
       --  later when we transform control flow statements inside parallel
       --  scopes.
 
-      if Is_Parallel (Iter) then
+      if In_Outlined_Parallel (N) then
          Set_Is_Parallel_Loop_Scope (Ent);
       end if;
 
@@ -5871,10 +5875,6 @@ package body Sem_Ch5 is
       Typ   : Entity_Id;
 
    begin
-      if Is_Entity_Name (Iter_Name) then
-         return;
-      end if;
-
       --  If the domain of iteration is an array component that depends
       --  on a discriminant, create actual subtype for it. Preanalysis
       --  does not generate the actual subtype of a selected component.

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -124,12 +124,6 @@ package body Sem_Ch5 is
    --  the range in order to determine the expected type, and analyze and
    --  resolve the original bounds.
 
-   procedure Check_Static_Loop_Bounds
-     (N : Node_Id; DS : Node_Id; Loop_Nod : Node_Id);
-   --  Checks to see if a discrete subtype definition belonging to loop
-   --  parameter N contains any bounds that can be proven invalid at compile
-   --  time. Loop_Node is the loop statement parent of N.
-
    procedure Check_Controlled_Array_Attribute
      (DS : Node_Id; Loop_Nod : Node_Id);
    --  If a loop parameter's bounds are given by a 'Range reference on a
@@ -3133,7 +3127,232 @@ package body Sem_Ch5 is
          end;
       end if;
 
-      Check_Static_Loop_Bounds (N, DS, Loop_Nod);
+      --  Case where we have a range or a subtype, get type bounds
+
+      if Nkind (DS) in N_Range | N_Subtype_Indication
+        and then not Error_Posted (DS)
+        and then Etype (DS) /= Any_Type
+        and then Is_Discrete_Type (Etype (DS))
+      then
+         declare
+            L          : Node_Id;
+            H          : Node_Id;
+            Null_Range : Boolean := False;
+
+         begin
+            if Nkind (DS) = N_Range then
+               L := Low_Bound  (DS);
+               H := High_Bound (DS);
+            else
+               L :=
+                 Type_Low_Bound  (Underlying_Type (Etype (Subtype_Mark (DS))));
+               H :=
+                 Type_High_Bound (Underlying_Type (Etype (Subtype_Mark (DS))));
+            end if;
+
+            --  Check for null or possibly null range and issue warning. We
+            --  suppress such messages in generic templates and instances,
+            --  because in practice they tend to be dubious in these cases. The
+            --  check applies as well to rewritten array element loops where a
+            --  null range may be detected statically.
+
+            if Compile_Time_Compare (L, H, Assume_Valid => True) = GT then
+               if Compile_Time_Compare (L, H, Assume_Valid => False) = GT then
+                  --  Since we know the range of the loop is always null,
+                  --  set the appropriate flag to remove the loop entirely
+                  --  during expansion.
+
+                  if Nkind (Loop_Nod) = N_Loop_Statement then
+                     Set_Is_Null_Loop (Loop_Nod);
+                  end if;
+
+                  Null_Range := True;
+               end if;
+
+               --  Suppress the warning if inside a generic template or
+               --  instance, since in practice they tend to be dubious in these
+               --  cases since they can result from intended parameterization.
+
+               if Comes_From_Source (N)
+                 and then not Inside_A_Generic
+                 and then not In_Instance
+               then
+
+                  --  Specialize msg if invalid values could make the loop
+                  --  non-null after all.
+
+                  if Null_Range then
+                     if Nkind (N) = N_Chunk_Specification_Range then
+                        Error_Msg_N
+                          ("??chunk specification range is null, " &
+                           "Program_Error will be raised at runtime", DS);
+                     else
+                        Error_Msg_N
+                          ("??loop range is null, loop will not execute", DS);
+                     end if;
+
+                  --  Here is where the loop could execute because of
+                  --  invalid values, so issue appropriate message.
+
+                  else
+                     if Nkind (N) = N_Chunk_Specification_Range then
+                        Error_Msg_N
+                          ("??chunk specification range may be null," &
+                           " Program_Error could be raised at runtime", DS);
+                     else
+                        Error_Msg_N
+                          ("??loop range may be null, loop may" &
+                           " not execute", DS);
+                        Error_Msg_N
+                          ("??can only execute if invalid values are present",
+                           DS);
+                     end if;
+                  end if;
+               end if;
+
+               --  In either case, suppress warnings in the body of the loop,
+               --  since it is likely that these warnings will be inappropriate
+               --  if the loop never actually executes, which is likely.
+
+               if Nkind (Loop_Nod) = N_Loop_Statement then
+                  Set_Suppress_Loop_Warnings (Loop_Nod);
+               end if;
+
+               --  The other case for a warning is a reverse loop where the
+               --  upper bound is the integer literal zero or one, and the
+               --  lower bound may exceed this value.
+
+               --  For example, we have
+
+               --     for J in reverse N .. 1 loop
+
+               --  In practice, this is very likely to be a case of reversing
+               --  the bounds incorrectly in the range.
+
+            elsif Nkind (N) /= N_Chunk_Specification_Range
+              and then Reverse_Present (N)
+              and then Nkind (Original_Node (H)) = N_Integer_Literal
+              and then
+                (Intval (Original_Node (H)) = Uint_0
+                  or else
+                 Intval (Original_Node (H)) = Uint_1)
+            then
+               --  Lower bound may in fact be known and known not to exceed
+               --  upper bound (e.g. reverse 0 .. 1) and that's OK.
+
+               if Compile_Time_Known_Value (L)
+                 and then Expr_Value (L) <= Expr_Value (H)
+               then
+                  null;
+
+               --  Otherwise warning is warranted
+
+               else
+                  Error_Msg_N ("??loop range may be null", DS);
+                  Error_Msg_N ("\??bounds may be wrong way round", DS);
+               end if;
+            end if;
+
+            --  Check if either bound is known to be outside the range of the
+            --  loop parameter type, this is e.g. the case of a loop from
+            --  20..X where the type is 1..19.
+
+            --  Such a loop is dubious since either it raises CE or it executes
+            --  zero times, and that cannot be useful!
+
+            if Etype (DS) /= Any_Type
+              and then not Error_Posted (DS)
+              and then Nkind (DS) = N_Subtype_Indication
+              and then Nkind (Constraint (DS)) = N_Range_Constraint
+            then
+               declare
+                  LLo : constant Node_Id :=
+                          Low_Bound  (Range_Expression (Constraint (DS)));
+                  LHi : constant Node_Id :=
+                          High_Bound (Range_Expression (Constraint (DS)));
+
+                  Bad_Bound : Node_Id := Empty;
+                  --  Suspicious loop bound
+
+               begin
+                  --  At this stage L, H are the bounds of the type, and LLo
+                  --  Lhi are the low bound and high bound of the loop.
+
+                  if Compile_Time_Compare (LLo, L, Assume_Valid => True) = LT
+                       or else
+                     Compile_Time_Compare (LLo, H, Assume_Valid => True) = GT
+                  then
+                     Bad_Bound := LLo;
+                  end if;
+
+                  if Compile_Time_Compare (LHi, L, Assume_Valid => True) = LT
+                       or else
+                     Compile_Time_Compare (LHi, H, Assume_Valid => True) = GT
+                  then
+                     Bad_Bound := LHi;
+                  end if;
+
+                  if Present (Bad_Bound) then
+                     if Nkind (N) = N_Chunk_Specification_Range then
+                        Error_Msg_N
+                          ("Suspicious chunk_index range: out of range " &
+                           "of chunk_index subtype. ""Constraint_Error"" " &
+                           "will be raised at run-time.??", Bad_Bound);
+                     else
+                        Error_Msg_N
+                          ("suspicious loop bound out of range of "
+                           & "loop subtype??", Bad_Bound);
+                        Error_Msg_N
+                          ("\loop executes zero times or raises "
+                           & "Constraint_Error??", Bad_Bound);
+                     end if;
+                  end if;
+
+                  if Compile_Time_Compare (LLo, LHi, Assume_Valid => False)
+                    = GT
+                  then
+                     Error_Msg_N ("??constrained range is null",
+                       Constraint (DS));
+
+                     --  Additional constraints on modular types can be
+                     --  confusing, add more information.
+
+                     if Ekind (Etype (DS)) = E_Modular_Integer_Subtype then
+                        Error_Msg_Uint_1 := Intval (LLo);
+                        Error_Msg_Uint_2 := Intval (LHi);
+                        Error_Msg_NE ("\iterator has modular type &, " &
+                          "so the loop has bounds ^ ..^",
+                          Constraint (DS),
+                          Subtype_Mark (DS));
+                     end if;
+
+                     if Nkind (Loop_Nod) = N_Loop_Statement then
+                        Set_Is_Null_Loop (Loop_Nod);
+
+                        --  Suppress other warnings about the body of the loop,
+                        --  as it will never execute.
+                        Set_Suppress_Loop_Warnings (Loop_Nod);
+                     end if;
+                  end if;
+               end;
+            end if;
+
+         --  This declare block is about warnings, if we get an exception while
+         --  testing for warnings, we simply abandon the attempt silently. This
+         --  most likely occurs as the result of a previous error, but might
+         --  just be an obscure case we have missed. In either case, not giving
+         --  the warning is perfectly acceptable.
+
+         exception
+            when others =>
+               --  With debug flag K we will get an exception unless an error
+               --  has already occurred (useful for debugging).
+
+               if Debug_Flag_K then
+                  Check_Error_Detected;
+               end if;
+         end;
+      end if;
 
       --  Preanalyze the filter. Expansion will take place when enclosing
       --  loop is expanded.
@@ -5560,226 +5779,6 @@ package body Sem_Ch5 is
          Rewrite (High_Bound (R), New_Copy (New_Hi));
       end if;
    end Process_Bounds;
-
-   ------------------------------
-   -- Check_Static_Loop_Bounds --
-   ------------------------------
-
-   procedure Check_Static_Loop_Bounds
-     (N : Node_Id; DS : Node_Id; Loop_Nod : Node_Id)
-   is
-      L, H : Node_Id;
-      Null_Range : Boolean := False;
-
-   begin
-
-      if Nkind (DS) not in N_Range | N_Subtype_Indication
-        or else Error_Posted (DS)
-        or else Etype (DS) = Any_Type
-        or else not Is_Discrete_Type (Etype (DS))
-      then
-         return;
-      end if;
-
-      --  Case where we have a range or a subtype, get type bounds
-
-      if Nkind (DS) = N_Range then
-         L := Low_Bound  (DS);
-         H := High_Bound (DS);
-      else
-         L :=
-            Type_Low_Bound  (Underlying_Type (Etype (Subtype_Mark (DS))));
-         H :=
-            Type_High_Bound (Underlying_Type (Etype (Subtype_Mark (DS))));
-      end if;
-
-      --  Check for null or possibly null range and issue warning. We
-      --  suppress such messages in generic templates and instances,
-      --  because in practice they tend to be dubious in these cases. The
-      --  check applies as well to rewritten array element loops where a
-      --  null range may be detected statically.
-
-      if Compile_Time_Compare (L, H, Assume_Valid => True) = GT then
-         if Compile_Time_Compare (L, H, Assume_Valid => False) = GT then
-            --  Since we know the range of the loop is always null,
-            --  set the appropriate flag to remove the loop entirely
-            --  during expansion.
-
-            if Nkind (Loop_Nod) = N_Loop_Statement then
-               Set_Is_Null_Loop (Loop_Nod);
-            end if;
-
-            Null_Range := True;
-         end if;
-
-         --  Suppress the warning if inside a generic template or
-         --  instance, since in practice they tend to be dubious in these
-         --  cases since they can result from intended parameterization.
-
-         if Comes_From_Source (N)
-           and then not Inside_A_Generic
-           and then not In_Instance
-         then
-
-            --  Specialize msg if invalid values could make the loop
-            --  non-null after all.
-
-            if Null_Range then
-               if Nkind (N) = N_Chunk_Specification_Range then
-                  Error_Msg_N
-                    ("??chunk specification range is null, " &
-                     "Program_Error will be raised at runtime", DS);
-               else
-                  Error_Msg_N
-                    ("??loop range is null, loop will not execute", DS);
-               end if;
-
-            --  Here is where the loop could execute because of
-            --  invalid values, so issue appropriate message.
-
-            else
-               if Nkind (N) = N_Chunk_Specification_Range then
-                  Error_Msg_N
-                    ("??chunk specification range may be null," &
-                     " Program_Error could be raised at runtime", DS);
-               else
-                  Error_Msg_N
-                    ("??loop range may be null, loop may" &
-                     " not execute", DS);
-                  Error_Msg_N
-                    ("??can only execute if invalid values are present",
-                     DS);
-               end if;
-            end if;
-         end if;
-
-         --  In either case, suppress warnings in the body of the loop,
-         --  since it is likely that these warnings will be inappropriate
-         --  if the loop never actually executes, which is likely.
-
-         if Nkind (Loop_Nod) = N_Loop_Statement then
-            Set_Suppress_Loop_Warnings (Loop_Nod);
-         end if;
-
-         --  The other case for a warning is a reverse loop where the
-         --  upper bound is the integer literal zero or one, and the
-         --  lower bound may exceed this value.
-
-         --  For example, we have
-
-         --     for J in reverse N .. 1 loop
-
-         --  In practice, this is very likely to be a case of reversing
-         --  the bounds incorrectly in the range.
-
-      elsif Nkind (N) /= N_Chunk_Specification_Range
-        and then Reverse_Present (N)
-        and then Nkind (Original_Node (H)) = N_Integer_Literal
-        and then
-          (Intval (Original_Node (H)) = Uint_0
-            or else
-           Intval (Original_Node (H)) = Uint_1)
-      then
-         --  Lower bound may in fact be known and known not to exceed
-         --  upper bound (e.g. reverse 0 .. 1) and that's OK.
-
-         if Compile_Time_Known_Value (L)
-           and then Expr_Value (L) <= Expr_Value (H)
-         then
-            null;
-
-         --  Otherwise warning is warranted
-
-         else
-            Error_Msg_N ("??loop range may be null", DS);
-            Error_Msg_N ("\??bounds may be wrong way round", DS);
-         end if;
-      end if;
-
-      --  Check if either bound is known to be outside the range of the
-      --  loop parameter type, this is e.g. the case of a loop from
-      --  20..X where the type is 1..19.
-
-      --  Such a loop is dubious since either it raises CE or it executes
-      --  zero times, and that cannot be useful!
-
-      if Etype (DS) /= Any_Type
-        and then not Error_Posted (DS)
-        and then Nkind (DS) = N_Subtype_Indication
-        and then Nkind (Constraint (DS)) = N_Range_Constraint
-      then
-         declare
-            LLo : constant Node_Id :=
-                    Low_Bound  (Range_Expression (Constraint (DS)));
-            LHi : constant Node_Id :=
-                    High_Bound (Range_Expression (Constraint (DS)));
-
-            Bad_Bound : Node_Id := Empty;
-            --  Suspicious loop bound
-
-         begin
-            --  At this stage L, H are the bounds of the type, and LLo
-            --  Lhi are the low bound and high bound of the loop.
-
-            if Compile_Time_Compare (LLo, L, Assume_Valid => True) = LT
-                or else
-              Compile_Time_Compare (LLo, H, Assume_Valid => True) = GT
-            then
-               Bad_Bound := LLo;
-            end if;
-
-            if Compile_Time_Compare (LHi, L, Assume_Valid => True) = LT
-                or else
-              Compile_Time_Compare (LHi, H, Assume_Valid => True) = GT
-            then
-               Bad_Bound := LHi;
-            end if;
-
-            if Present (Bad_Bound) then
-               if Nkind (N) = N_Chunk_Specification_Range then
-                  Error_Msg_N
-                    ("Suspicious chunk_index range: out of range " &
-                     "of chunk_index subtype. ""Constraint_Error"" " &
-                     "will be raised at run-time.??", Bad_Bound);
-               else
-                  Error_Msg_N
-                    ("suspicious loop bound out of range of "
-                     & "loop subtype??", Bad_Bound);
-                  Error_Msg_N
-                    ("\loop executes zero times or raises "
-                     & "Constraint_Error??", Bad_Bound);
-               end if;
-            end if;
-
-            if Compile_Time_Compare (LLo, LHi, Assume_Valid => False)
-              = GT
-            then
-               Error_Msg_N ("??constrained range is null",
-                 Constraint (DS));
-
-               --  Additional constraints on modular types can be
-               --  confusing, add more information.
-
-               if Ekind (Etype (DS)) = E_Modular_Integer_Subtype then
-                  Error_Msg_Uint_1 := Intval (LLo);
-                  Error_Msg_Uint_2 := Intval (LHi);
-                  Error_Msg_NE ("\iterator has modular type &, " &
-                    "so the loop has bounds ^ ..^",
-                    Constraint (DS),
-                    Subtype_Mark (DS));
-               end if;
-
-               if Nkind (Loop_Nod) = N_Loop_Statement then
-                  Set_Is_Null_Loop (Loop_Nod);
-
-                  --  Suppress other warnings about the body of the loop,
-                  --  as it will never execute.
-                  Set_Suppress_Loop_Warnings (Loop_Nod);
-               end if;
-            end if;
-         end;
-      end if;
-   end Check_Static_Loop_Bounds;
 
    --------------------------------------
    -- Check_Controlled_Array_Attribute --

--- a/gcc/ada/sinfo.ads
+++ b/gcc/ada/sinfo.ads
@@ -2204,12 +2204,12 @@ package Sinfo is
    --    expansion, these declarations are moved inside an enclosing block.
 
    --  Parallel_Low_Bound
-   --    Applies to N_Parallel_Block_Statement. Contains a reference to the
-   --    parallel outlined procedure's Low parameter.
+   --    Applies to N_Parallel_Block_Statement and N_Loop_Statement. Contains
+   --    a reference to the parallel outlined procedure's Low parameter.
 
    --  Parallel_Hi_Bound
-   --    Applies to N_Parallel_Block_Statement. Contains a reference to the
-   --    parallel outlined procedure's Hi parameter.
+   --    Applies to N_Parallel_Block_Statement and N_Loop_Statement. Contains
+   --    a reference to the parallel outlined procedure's Hi parameter.
 
    --  Parent_Spec
    --    For a library unit that is a child unit spec (package or subprogram

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for6.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for6.adb
@@ -1,0 +1,63 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with System.Atomic_Operations.Integer_Arithmetic;
+
+procedure parallel_for6 is
+   subtype Chunk_Number is Natural range 1 .. 8;
+
+   type Atomic_Int is new Integer with Atomic;
+
+   package Int_Atomic is new
+     System.Atomic_Operations.Integer_Arithmetic
+       (Atomic_Type => Atomic_Int);
+
+   Ran_A : aliased Atomic_Int := 0;
+   Ran_B : aliased Atomic_Int := 0;
+   Ran_C : aliased Atomic_Int := 0;
+   Ran_D : aliased Atomic_Int := 0;
+
+   function Test_A (A : Integer) return Integer is
+   begin
+      Int_Atomic.Atomic_Add (Ran_A, 1);
+      return A * 2;
+   end Test_A;
+
+   function Test_B (B : Integer) return Integer is
+   begin
+      Int_Atomic.Atomic_Add (Ran_B, 1);
+      return B * 3;
+   end Test_B;
+
+   function Test_C (C : Integer) return Integer is
+   begin
+      Int_Atomic.Atomic_Add (Ran_C, 1);
+      return C * 3 - 1;
+   end Test_C;
+begin
+   parallel (Chunk_Index in Chunk_Number range Test_A (1) .. Test_B (2))
+      for I in Test_C (1) .. 6 loop
+         Int_Atomic.Atomic_Add (Ran_D, 1);
+      end loop;
+
+   if Ran_A /= 1 then
+      raise Program_Error;
+   end if;
+
+   if Ran_B /= 1 then
+      raise Program_Error;
+   end if;
+
+   if Ran_C /= 1 then
+      raise Program_Error;
+   end if;
+
+   if Ran_D /= 5 then
+      raise Program_Error;
+   end if;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for6;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for7.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for7.adb
@@ -1,0 +1,71 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with System.Atomic_Operations.Integer_Arithmetic;
+
+procedure parallel_for7 is
+   type Int_Arr is array (2 .. 10) of Integer;
+   function Gen_Arr return Int_Arr;
+
+   type Atomic_Int is new Integer with Atomic;
+   package Int_Atomic is new
+     System.Atomic_Operations.Integer_Arithmetic
+       (Atomic_Type => Atomic_Int);
+
+   Ran_Gen_Arr : aliased Atomic_Int := 0;
+   Ran_Loop_1  : aliased Atomic_Int := 0;
+   Ran_Loop_2  : aliased Atomic_Int := 0;
+   Ran_Loop_3  : aliased Atomic_Int := 0;
+
+   Arr : Int_Arr := (1, 2, 3,
+                     4, 5, 6,
+                     7, 8, 9);
+
+   function Gen_Arr return Int_Arr is
+   begin
+      Ran_Gen_Arr := Ran_Gen_Arr + 1;
+      return Arr;
+   end Gen_Arr;
+begin
+   parallel for I in Gen_Arr'Range loop
+      Ran_Loop_1 := Ran_Loop_1 + 1;
+   end loop;
+
+   parallel for I in Arr'Range loop
+      Ran_Loop_2 := Ran_Loop_2 + 1;
+   end loop;
+
+   parallel (CI in Gen_Arr'Range)
+      for I in 1 .. 100 loop
+         Ran_Loop_3 := Ran_Loop_3 + 1;
+      end loop;
+
+   if Ran_Gen_Arr /= 2 then
+      raise Program_Error;
+   end if;
+
+   if Ran_Loop_1 /= 9 then
+      raise Program_Error;
+   end if;
+
+   if Ran_Loop_2 /= 9 then
+      raise Program_Error;
+   end if;
+
+   if Ran_Loop_3 /= 100 then
+      raise Program_Error;
+   end if;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+
+   if Mock_Check_Loop (2) /= ENDED then
+      raise Program_Error;
+   end if;
+
+   if Mock_Check_Loop (3) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for7;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for8.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for8.adb
@@ -1,0 +1,21 @@
+-- { dg-do compile }
+-- { dg-options "-gnat2022 -Werror" }
+
+with Ada.Text_IO; use Ada.Text_IO;
+
+procedure parallel_for8 is
+   subtype A is Integer range 1 .. 10;
+begin
+   parallel for I in 3 .. 2 loop -- { dg-error "warning: loop range is null, loop will not execute" }
+      Put_Line ("Unreachable");
+   end loop;
+
+   parallel (Ch in A range 5 .. 15)
+      for I in 1 .. 100 loop
+         Put_Line ("Unreachable");
+      end loop;
+end parallel_for8;
+
+-- { dg-error "warning: static value out of range of type \"A\" defined at line 7" "" { target *-*-* } 13 }
+-- { dg-error "warning: Constraint_Error will be raised at run time" "" { target *-*-* } 13 }
+-- { dg-error "warning: Suspicious chunk_index range: out of range of chunk_index subtype. \"Constraint_Error\" will be raised at run-time." "" { target *-*-* } 13 }

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr1.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr1.adb
@@ -1,0 +1,95 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with System.Atomic_Operations.Integer_Arithmetic;
+
+procedure parallel_for_arr1 is
+   type Atomic_Int is new Integer with Atomic;
+   package Int_Atomic is new
+     System.Atomic_Operations.Integer_Arithmetic
+       (Atomic_Type => Atomic_Int);
+
+   Ran_A : aliased Atomic_Int := 0;
+   Ran_B : aliased Atomic_Int := 0;
+   Ran_C : aliased Atomic_Int := 0;
+
+   type Color is (Red, Green, Blue,
+     Orange, Purple, Yellow);
+   type Byte is new Integer range 0 .. 255;
+
+   type Arr_3D_Type is array
+     (1 .. 3, Color, Byte range 3 .. 7)
+      of Integer;
+   Total_Items : constant Integer :=
+     Arr_3D_Type'Length (1) * Arr_3D_Type'Length (2) *
+       Arr_3D_Type'Length (3);
+
+   function Gen_Arr return Arr_3D_Type;
+   function Gen_Hi (I : Integer) return Integer;
+   function Gen_Lo (I : Integer) return Integer;
+
+   function Gen_Arr return Arr_3D_Type is
+      Counter : Integer := 1;
+      Arr_3D  : Arr_3D_Type;
+   begin
+      for Val of Arr_3D loop
+         Val := Counter;
+         Counter := Counter + 1;
+      end loop;
+
+      Int_Atomic.Atomic_Add (Ran_A, 1);
+      return Arr_3D;
+   end Gen_Arr;
+
+   function Gen_Lo (I : Integer) return Integer is
+   begin
+      Int_Atomic.Atomic_Add (Ran_B, 1);
+      return I + 1;
+   end Gen_Lo;
+
+   function Gen_Hi (I : Integer) return Integer is
+   begin
+      Int_Atomic.Atomic_Add (Ran_C, 1);
+      return I + 3;
+   end Gen_Hi;
+
+   Visited : array (1 .. Total_Items) of Boolean :=
+     (others => False);
+   Chunks  : array (3 .. 6) of Boolean;
+
+begin
+   parallel (Chunk_Ind in Gen_Lo (2) .. Gen_Hi (3))
+      for Val of Gen_Arr loop
+         Visited (Val) := True;
+         Chunks (Chunk_Ind) := True;
+      end loop;
+
+   for Ind in Visited'Range loop
+      if not Visited (Ind) Then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   for Ind in Chunks'Range loop
+      if not Chunks (Ind) Then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   if Ran_A /= 1 then
+      raise Program_Error;
+   end if;
+
+   if Ran_B /= 1 then
+      raise Program_Error;
+   end if;
+
+   if Ran_C /= 1 then
+      raise Program_Error;
+   end if;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr1;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr2.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr2.adb
@@ -1,0 +1,22 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+
+procedure parallel_for_arr2 is
+   Arr : array (1 .. 6) of Integer := (0, 1, 0, 1, 0, 1);
+begin
+   parallel for Val of Arr when Val = 0 loop
+      Val := 2;
+   end loop;
+
+   for Ind in Arr'Range loop
+      if Arr (Ind) /= Ind mod 2 + 1 then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr2;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr3.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr3.adb
@@ -2,7 +2,6 @@
 -- { dg-options "-gnat2022" }
 
 with LWT.Parallelism; use LWT.Parallelism;
-with Ada.Text_IO; use Ada.Text_IO;
 
 procedure parallel_for_arr3 is
    type Array_2D is array

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr3.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr3.adb
@@ -1,0 +1,46 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with Ada.Text_IO; use Ada.Text_IO;
+
+procedure parallel_for_arr3 is
+   type Array_2D is array
+     (Positive range <>, Positive range <>)
+      of Integer;
+
+   procedure Process_Arr
+     (A : Positive; B : Positive);
+
+   procedure Process_Arr
+     (A : Positive; B : Positive)
+   is
+      C : constant Positive := A * B;
+      Arr : Array_2D (1 .. A, 1 .. B);
+      Counter : Integer := 1;
+      Visited : array (1 .. C) of Boolean := (others => False);
+   begin
+      for I in Arr'Range (1) loop
+         for J in Arr'Range (2) loop
+            Arr (I, J) := Counter;
+            Counter := Counter + 1;
+         end loop;
+      end loop;
+
+      parallel for Val of Arr loop
+         Visited (Val) := True;
+      end loop;
+
+      for I in Visited'Range loop
+         if not Visited (I) then
+            raise Program_Error;
+         end if;
+      end loop;
+   end Process_Arr;
+begin
+   Process_Arr (3, 4);
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr3;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr4.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr4.adb
@@ -1,0 +1,53 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with Ada.Text_IO; use Ada.Text_IO;
+
+procedure parallel_for_arr4 is
+   type Array_2D is array
+     (Positive range <>, Positive range <>)
+      of Integer;
+
+   function Gen_Arr
+     (A : Positive; B : Positive)
+      return Array_2D;
+
+   function Gen_Arr
+     (A : Positive; B : Positive)
+      return Array_2D
+   is
+      Arr : Array_2D (1 .. A, 1 .. B);
+      Counter : Integer := 1;
+   begin
+      for I in Arr'Range (1) loop
+         for J in Arr'Range (2) loop
+            Arr (I, J) := Counter;
+            Counter := Counter + 1;
+         end loop;
+      end loop;
+
+      return Arr;
+   end Gen_Arr;
+
+   A : constant Positive := 3;
+   B : constant Positive := 4;
+   C : constant Positive := A * B;
+
+   Visited : array (1 .. C) of Boolean := (others => False);
+begin
+
+   parallel for Val of Gen_Arr (A, B) loop
+      Visited (Val) := True;
+   end loop;
+
+   for I in Visited'Range loop
+      if not Visited (I) then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr4;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr4.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr4.adb
@@ -2,7 +2,6 @@
 -- { dg-options "-gnat2022" }
 
 with LWT.Parallelism; use LWT.Parallelism;
-with Ada.Text_IO; use Ada.Text_IO;
 
 procedure parallel_for_arr4 is
    type Array_2D is array

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr5.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr5.adb
@@ -2,7 +2,6 @@
 -- { dg-options "-gnat2022" }
 
 with LWT.Parallelism; use LWT.Parallelism;
-with Ada.Text_IO; use Ada.Text_IO;
 
 procedure parallel_for_arr5 is
    type Array_2D is array

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr5.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr5.adb
@@ -1,0 +1,63 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with Ada.Text_IO; use Ada.Text_IO;
+
+procedure parallel_for_arr5 is
+   type Array_2D is array
+     (Positive range <>, Positive range <>)
+      of Integer;
+
+   A : constant Integer := 6;
+   B : constant Integer := 7;
+   C : constant Integer := A * B;
+   Visited : array (1 .. C) of Boolean := (others => False);
+
+   procedure Run_Test (Arr : in out Array_2D);
+
+   procedure Process_Arr
+     (A : Positive; B : Positive);
+
+   procedure Run_Test (Arr : in out Array_2D) is
+   begin
+      parallel for Val of Arr loop
+         Visited (Val) := True;
+         Val := 0;
+      end loop;
+   end Run_Test;
+
+   procedure Process_Arr
+     (A : Positive; B : Positive)
+   is
+      Arr : Array_2D (1 .. A, 1 .. B);
+      Counter : Integer := 1;
+   begin
+      for I in Arr'Range (1) loop
+         for J in Arr'Range (2) loop
+            Arr (I, J) := Counter;
+            Counter := Counter + 1;
+         end loop;
+      end loop;
+
+      Run_Test (Arr);
+
+      for I in Visited'Range loop
+         if not Visited (I) then
+            raise Program_Error;
+         end if;
+      end loop;
+
+      for I of Arr loop
+         if I /= 0 then
+            raise Program_Error;
+         end if;
+      end loop;
+   end Process_Arr;
+begin
+   Process_Arr (A, B);
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr5;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr6.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr6.adb
@@ -1,0 +1,51 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+
+procedure parallel_for_arr6 is
+   A : constant Integer := 42;
+   B : constant Integer := 15;
+
+   Chunks : array (1 .. 2) of Boolean := (others => False);
+   Arr : array (1 .. 20) of Integer := (others => A);
+
+   procedure Run_Test (Low : Integer; Hi : Integer) is
+   begin
+      parallel (Chunk_Id in Chunks'Range)
+         for I of Arr (Low .. Hi) loop
+            Chunks (Chunk_Id) := True;
+            I := B;
+         end loop;
+   end Run_Test;
+begin
+   Run_Test (5, 10);
+
+   for I in 5 .. 10 loop
+      if Arr (I) /= B then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   for I in 1 .. 4 loop
+      if Arr (I) /= A then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   for I in 11 .. 20 loop
+      if Arr (I) /= A then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   for Visited of Chunks loop
+      if not Visited then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr6;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7.adb
@@ -1,0 +1,38 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with parallel_for_arr7_pkg;
+
+procedure parallel_for_arr7 is
+
+   Lo : constant Natural := 1;
+   Hi : constant Natural := 3;
+
+   Visited : array (Lo .. Hi) of Boolean := (others => False);
+
+   procedure Print_Int (I : Integer) is
+   begin
+      Visited (I) := True;
+   end Print_Int;
+
+   package Inst is new parallel_for_arr7_pkg
+     (Element_Type => Integer,
+      Element_Operation => Print_Int);
+   
+   Arr : Inst.Arr_Typ (1 .. 3) := (1, 2, 3);
+begin
+
+   Inst.run_test (Arr);
+
+   for V of Visited loop
+      if not V then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+
+end parallel_for_arr7;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7.adb
@@ -11,14 +11,14 @@ procedure parallel_for_arr7 is
 
    Visited : array (Lo .. Hi) of Boolean := (others => False);
 
-   procedure Print_Int (I : Integer) is
+   procedure Visit (I : Integer) is
    begin
       Visited (I) := True;
-   end Print_Int;
+   end Visit;
 
    package Inst is new parallel_for_arr7_pkg
      (Element_Type => Integer,
-      Element_Operation => Print_Int);
+      Element_Operation => Visit);
    
    Arr : Inst.Arr_Typ (1 .. 3) := (1, 2, 3);
 begin

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7_pkg.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7_pkg.adb
@@ -1,0 +1,12 @@
+-- { dg-options "-gnat2022" }
+
+package body parallel_for_arr7_pkg is
+
+   procedure run_test (A : Arr_Typ) is
+   begin
+      parallel for E of A loop
+         Element_Operation (E);
+      end loop;
+   end run_test;
+
+end parallel_for_arr7_pkg;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7_pkg.ads
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr7_pkg.ads
@@ -1,0 +1,7 @@
+generic
+   type Element_Type is private;
+   with procedure Element_Operation (E : Element_Type);
+package parallel_for_arr7_pkg is
+   type Arr_Typ is array (Positive range <>) of Element_Type;
+   procedure run_test (A : Arr_Typ);
+end parallel_for_arr7_pkg;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr8.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr8.adb
@@ -1,0 +1,46 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+with parallel_for_arr8_pkg;
+
+procedure parallel_for_arr8 is
+   Lo : constant Positive := 1;
+   Hi : constant Positive := 4;
+
+   type Rng is array (Positive range <>) of Natural;
+   Visited : array (Lo .. Hi) of Boolean := (others => False);
+
+   function Gen return Rng is
+   begin
+      return (1, 2, 3, 4);
+   end Gen;
+   
+   procedure Element_Operation (E : Natural) is
+   begin
+      Visited (E) := True;
+   end Element_Operation;
+
+   package Inst is new parallel_for_arr8_pkg
+     (Lo => Lo,
+      Hi => Hi,
+      Element_Type => Natural,
+      Arr_Type => Rng,
+      Element_Operation => Element_Operation,
+      Gen_Val => Gen);
+
+begin
+
+   Inst.run_test;
+
+   for V of Visited loop
+      if not V then
+         raise Program_Error;
+      end if;
+   end loop;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+
+end parallel_for_arr8;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr8_pkg.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr8_pkg.adb
@@ -1,0 +1,12 @@
+-- { dg-options "-gnat2022" }
+
+package body parallel_for_arr8_pkg is
+
+   procedure run_test is
+   begin
+      parallel for E of Gen_Val loop
+         Element_Operation (E);
+      end loop;
+   end run_test;
+
+end parallel_for_arr8_pkg;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr8_pkg.ads
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr8_pkg.ads
@@ -1,0 +1,14 @@
+generic
+   Lo, Hi : Positive;
+
+   type Element_Type is private;
+   with procedure Element_Operation (E : Element_Type);
+
+   type Arr_Type is array (Positive range <>) of Element_Type;
+   with function Gen_Val return Arr_Type;
+
+package parallel_for_arr8_pkg is
+
+   procedure run_test;
+
+end parallel_for_arr8_pkg;

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_err2.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_err2.adb
@@ -3,7 +3,7 @@
 
 with Ada.Text_IO; use Ada.Text_IO;
 
-procedure parallel_for8 is
+procedure parallel_for_err2 is
    subtype A is Integer range 1 .. 10;
 begin
    parallel for I in 3 .. 2 loop -- { dg-error "warning: loop range is null, loop will not execute" }
@@ -14,7 +14,7 @@ begin
       for I in 1 .. 100 loop
          Put_Line ("Unreachable");
       end loop;
-end parallel_for8;
+end parallel_for_err2;
 
 -- { dg-error "warning: static value out of range of type \"A\" defined at line 7" "" { target *-*-* } 13 }
 -- { dg-error "warning: Constraint_Error will be raised at run time" "" { target *-*-* } 13 }


### PR DESCRIPTION
This pull request is dependent on #17. This patch moves loop range expansion for loop parameters (e.g. transforming the loop param into `Low_Arg .. Hi_Arg`) into the expansion phase and adds an expansion function for arrays. It also simplifies the expansion for `My_Type'Range` loop parameters by getting rid of the check for subtype marks with side effects (`Resolve` already takes care of this).

TODO:
- [x] Comments
- [x] Cleanup
  - [x] Move array expansion into its own function
  - [x] Move `Check_Static_Loop_Bounds` back into `Analyze_Loop_Parameter_Specification`. I don't *think* we need in the package scope anymore because the loop does get analyzed in its "original" form inside the loop, the main difference is that the loop parameter discrete subtype values have been resolved in their original scope.
- [x] Iteration over index types of `N_Range` kind (e.g. `array (1 .. 3) of` instead of `array (Positive range ..)  of`)
- [x] Fix chunk index handling in array loops
- [x] Add tests
- [x] Variable length arrays
