### PR TITLE
Move loop label into outlined scope before analysis

### DIFF
--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -4080,6 +4080,8 @@ package body Sem_Ch5 is
 
             --  Move the loop inside the outlined procedure
 
+            Set_Scope (Loop_Id, Spec_Id);
+
             Insert_Before_And_Analyze (N, Make_Subprogram_Body (Loc,
               Specification              => Outlined_Spec,
               Declarations               => Decls,
@@ -4109,12 +4111,6 @@ package body Sem_Ch5 is
                Insert_After_And_Analyze (N,
                  Parallel_Exit_Actions (Spec_Id));
             end if;
-
-            --  Move the loop label into the outlined procedure
-            --  scope
-
-            Remove_Entity (Loop_Id);
-            Append_Entity (Loop_Id, Spec_Id);
          end Create_Par_Range_Loop;
 
          ----------------------------

--- a/gcc/testsuite/gnat.dg/parallel/parallel_for_arr9.adb
+++ b/gcc/testsuite/gnat.dg/parallel/parallel_for_arr9.adb
@@ -1,0 +1,54 @@
+-- { dg-do run }
+-- { dg-options "-gnat2022" }
+
+with LWT.Parallelism; use LWT.Parallelism;
+
+--  NOTE: This test relies on the Mock LWT being sequential.
+--  This test will fail for parallel implementations of LWT.
+
+procedure parallel_for_arr9 is
+   X_Max : constant Natural := 2;
+   Y_Max : constant Natural := 3;
+   Total_Len : constant Natural := X_Max * Y_Max;
+
+   type X is new Natural range 1 .. X_Max;
+   type Y is new Natural range 1 .. Y_Max;
+
+   type Arr_2D_Row is array (X, Y) of Natural;
+   type Arr_2D_Col is array (X, Y) of Natural;
+   pragma Convention(Fortran, Arr_2D_Col);
+   type Arr_1D is array (1 .. Total_Len) of Natural;
+
+   Row_Arr : Arr_2D_Row := ((1, 2, 3), (4, 5, 6));
+   Col_Arr : Arr_2D_Col := ((1, 2, 3), (4, 5, 6));
+
+   Row_Ord : aliased constant Arr_1D := (1, 2, 3, 4, 5, 6);
+   Col_Ord : aliased constant Arr_1D := (1, 4, 2, 5, 3, 6);
+
+   Row_Ind : Integer := 1;
+   Col_Ind : Integer := 1;
+begin
+   parallel
+   for Row_Val of Row_Arr loop
+      if Row_Val /= Row_Ord (Row_Ind) then
+         raise Program_Error;
+      end if;
+      Row_Ind := Row_Ind + 1;
+   end loop;
+
+   parallel
+   for Col_Val of Col_Arr loop
+      if Col_Val /= Col_Ord (Col_Ind) then
+         raise Program_Error;
+      end if;
+      Col_Ind := Col_Ind + 1;
+   end loop;
+
+   if Mock_Check_Loop (1) /= ENDED then
+      raise Program_Error;
+   end if;
+
+   if Mock_Check_Loop (2) /= ENDED then
+      raise Program_Error;
+   end if;
+end parallel_for_arr9;


### PR DESCRIPTION
This patch fixes a bug I found that causes the loop body to be analyzed in the wrong scope. Take the following example:

```ada
procedure Main_Proc is
   Counter : Integer := 1;

begin
   L_1: parallel for Val of 1 .. N loop
      ...
      Counter := Counter + 1;
   end loop L_1;
end Main_Proc;
```

This isn't safe code because it introduces a race condition, but the compiler does make an error during expansion. `Counter := Counter + 1;` expands to `Counter := 2;` because the outlined scope is skipped over during analysis. At this point, `L_1`'s parent is still `Main_Proc` instead of the outlined scope, which breaks the front end's constant analysis.

This PR fixes this bug by setting the loop's scope explicitly before analysis. I've also introduced a tests for this bug in addition to row/column major order support.