### PR TITLE
Fix compiler warnings

### DIFF
--- a/gcc/ada/exp_ch5.adb
+++ b/gcc/ada/exp_ch5.adb
@@ -5050,8 +5050,7 @@ package body Exp_Ch5 is
    end Expand_Iterator_Loop;
 
    procedure Expand_Parallel_Iterator_Loop (N : Node_Id) is
-      Scheme : constant Node_Id    := Iteration_Scheme (N);
-      Loc    : constant Source_Ptr := Sloc (N);
+      Scheme : constant Node_Id := Iteration_Scheme (N);
 
       pragma Assert (In_Outlined_Parallel (N));
       pragma Assert (Present (Iterator_Specification (Scheme)));
@@ -6637,16 +6636,13 @@ package body Exp_Ch5 is
       pragma Assert (In_Outlined_Parallel (N));
       pragma Assert (Present (Loop_Parameter_Specification (Scheme)));
 
-      Loop_Param : constant Node_Id := Loop_Parameter_Specification
-                                         (Scheme);
-      DS         : constant Node_Id := Discrete_Subtype_Definition
-                                         (Loop_Param);
-
-      Ident     : constant Entity_Id := Defining_Identifier (Loop_Param);
-      Low_Param : constant Entity_Id := Parallel_Low_Bound (N);
-      Hi_Param  : constant Entity_Id := Parallel_Hi_Bound (N);
-      New_Id    : constant Entity_Id := Make_Temporary (Loc, 'P');
-      Ltype     : constant Entity_Id := Etype (Ident);
+      Loop_Param : constant Node_Id   := Loop_Parameter_Specification
+                                           (Scheme);
+      Ident      : constant Entity_Id := Defining_Identifier (Loop_Param);
+      Low_Param  : constant Entity_Id := Parallel_Low_Bound (N);
+      Hi_Param   : constant Entity_Id := Parallel_Hi_Bound (N);
+      New_Id     : constant Entity_Id := Make_Temporary (Loc, 'P');
+      Ltype      : constant Entity_Id := Etype (Ident);
 
       New_Loop, New_Scheme, New_Body,
         New_Loop_Param, Param_Def : Node_Id;

--- a/gcc/ada/sem_ch5.adb
+++ b/gcc/ada/sem_ch5.adb
@@ -3752,8 +3752,7 @@ package body Sem_Ch5 is
                return Node_Id;
             --  Rewrites bound as reference to constant declaration
 
-            procedure Relocate_Subtype_Bounds
-              (S : Node_Id; Typ : Entity_Id);
+            procedure Relocate_Subtype_Bounds (S : Node_Id);
             --  Moves discrete subtype definition bounds into variables
             --  before the loop. This ensures that the bounds are not
             --  reevaluated inside the loop.
@@ -3804,9 +3803,7 @@ package body Sem_Ch5 is
             -- Relocate_Subtype_Bounds --
             -----------------------------
 
-            procedure Relocate_Subtype_Bounds
-              (S : Node_Id; Typ : Entity_Id)
-            is
+            procedure Relocate_Subtype_Bounds (S : Node_Id) is
                C  : constant Node_Id :=
                  Range_Expression (Constraint (S));
                SM : constant Entity_Id :=
@@ -3866,7 +3863,7 @@ package body Sem_Ch5 is
                  and then Present (Constraint (DS))
                  and then Nkind (Constraint (DS)) = N_Range_Constraint
                then
-                  Relocate_Subtype_Bounds (DS, Typ);
+                  Relocate_Subtype_Bounds (DS);
                end if;
             end if;
 
@@ -5806,8 +5803,6 @@ package body Sem_Ch5 is
    procedure Check_Controlled_Array_Attribute
      (DS : Node_Id; Loop_Nod : Node_Id)
    is
-      Loc : constant Source_Ptr := Sloc (Loop_Nod);
-
    begin
       if Nkind (DS) = N_Attribute_Reference
         and then Is_Entity_Name (Prefix (DS))


### PR DESCRIPTION
This patch fixes compiler warnings that prevent the project from building. These slipped by due to incremental builds but resurface when you build the project from scratch.